### PR TITLE
Feature: Skip Current Track

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -329,6 +329,41 @@ is observed, in the event the track is paused the value will be ``1`` else it wi
         "spotify_uri": "spotify:track:6FshvOVICpRVkwpYE5BYTD"
     }
 
+
+``DELETE``
+^^^^^^^^^^
+
+Issuing a ``DELETE`` to the current track resource will result in the track being skipped and the
+next track in the queue being played. This resource will always return a ``204``.
+
+.. code-block::
+
+    http -jv DELETE http://localhost/player/current
+
+    DELETE /player/current HTTP/1.1
+    Accept: application/json
+    Accept-Encoding: gzip, deflate
+    Connection: keep-alive
+    Content-Length: 0
+    Content-Type: application/json; charset=utf-8
+    Host: 192.168.59.103:5000
+    User-Agent: HTTPie/0.8.0
+
+    HTTP/1.0 204 NO CONTENT
+    Access-Control-Allow-Credentials: true
+    Access-Control-Allow-Expose-Headers: Link, Total-Pages, Total-Count
+    Access-Control-Allow-Origin: *
+    Cache-Control: no-cache, no-store, must-revalidate
+    Content-Length: 0
+    Content-Type: application/json; charset=utf-8
+    Date: Wed, 18 Mar 2015 13:24:29 GMT
+    Expires: 0
+    Pragma: no-cache
+    Server: Werkzeug/0.10.1 Python/2.7.3
+    Status: 204 No Content
+    Strict-Transport-Security: max-age=31536000; includeSubdomains; preload
+
+
 ``/player/pause``
 ~~~~~~~~~~~~~~~~~
 

--- a/tests/views/player/test_current.py
+++ b/tests/views/player/test_current.py
@@ -8,9 +8,11 @@ tests.views.player.test_current
 Unit tests for the ``fm.views.player.CurrentView`` class.
 """
 
+import json
 import mock
 
 from fm.ext import db
+from fm.views.player import CurrentView
 from fm.serializers.spotify import TrackSerialzier
 from flask import url_for
 from tests.factories.spotify import TrackFactory
@@ -24,23 +26,30 @@ class BaseCurrentTest(object):
         self.addPatchCleanup(patch)
 
 
-class TestCurrentGet(BaseCurrentTest):
+class TestGerCurrentTrack(BaseCurrentTest):
 
-    def should_return_no_content_if_no_data_in_redis(self):
+    def should_return_none_no_current_track_in_redis(self):
         self.redis.get.return_value = None
 
-        url = url_for('player.current')
-        response = self.client.get(url)
-
-        assert response.status_code == 204
+        assert CurrentView().get_current_track() is None
 
     def should_return_no_content_if_track_not_in_db(self):
         self.redis.get.return_value = 'spotify:track:foo'
 
-        url = url_for('player.current')
-        response = self.client.get(url)
+        assert CurrentView().get_current_track() is None
 
-        assert response.status_code == 204
+    def should_return_track_instance(self):
+        track = TrackFactory()
+
+        db.session.add(track)
+        db.session.commit()
+
+        self.redis.get.return_value = track.spotify_uri
+
+        assert CurrentView().get_current_track().id == track.id
+
+
+class TestCurrentGet(BaseCurrentTest):
 
     def should_return_track_data(self):
         track = TrackFactory()
@@ -55,3 +64,25 @@ class TestCurrentGet(BaseCurrentTest):
 
         assert response.status_code == 200
         assert response.json == TrackSerialzier().serialize(track)
+
+
+class TestCurrentDelete(BaseCurrentTest):
+
+    def should_fire_stop_event(self):
+        track = TrackFactory()
+
+        db.session.add(track)
+        db.session.commit()
+
+        self.redis.get.return_value = track.spotify_uri
+
+        url = url_for('player.current')
+        response = self.client.delete(url)
+
+        assert response.status_code == 204
+        self.redis.publish.assert_called_once_with(
+            self.app.config.get('PLAYER_CHANNEL'),
+            json.dumps({
+                'event': 'stop'
+            })
+        )


### PR DESCRIPTION
This PR adds Skip functionality to the API. This will require implementation in:

* Player
* FE Client

This is achieved by updating the `/player/current` resource to support `DELETE` requests. This has the same effect as `/player/pause` and `/player/resume`. The resource on a `DELETE` will publish a redis `stop` event which will trigger the player to stop the current track and play the next in the queue.