### PR TITLE
Feature: Mimic Spotify API Responses 

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -213,13 +213,6 @@ album and artist nested objects.
     [
         {
             "album": {
-                "artists": [
-                    {
-                        "id": "26556f7e-3304-4e51-8243-dd2199fcf6fa",
-                        "name": "Nightwish",
-                        "spotify_uri": "spotify:artist:2NPduAUeLVsfIauhRwuft1"
-                    }
-                ],
                 "id": "7f8bda77-5364-4902-9a98-208f1cdd7643",
                 "images": [
                     {
@@ -239,12 +232,19 @@ album and artist nested objects.
                     }
                 ],
                 "name": "Showtime, Storytime",
-                "spotify_uri": "spotify:album:1tZlCjdI2dcfBXP8iSDsSI"
+                "uri": "spotify:album:1tZlCjdI2dcfBXP8iSDsSI"
             },
+            "artists": [
+                {
+                    "id": "26556f7e-3304-4e51-8243-dd2199fcf6fa",
+                    "name": "Nightwish",
+                    "uri": "spotify:artist:2NPduAUeLVsfIauhRwuft1"
+                }
+            ],
             "duration": 272906,
             "id": "4b170737-017c-4e85-965c-47b8a158c789",
             "name": "Dark Chest Of Wonders - Live @ Wacken 2013",
-            "spotify_uri": "spotify:track:6FshvOVICpRVkwpYE5BYTD"
+            "uri": "spotify:track:6FshvOVICpRVkwpYE5BYTD"
         },
         ...
     ]
@@ -295,13 +295,6 @@ is observed, in the event the track is paused the value will be ``1`` else it wi
 
     {
         "album": {
-            "artists": [
-                {
-                    "id": "26556f7e-3304-4e51-8243-dd2199fcf6fa",
-                    "name": "Nightwish",
-                    "spotify_uri": "spotify:artist:2NPduAUeLVsfIauhRwuft1"
-                }
-            ],
             "id": "7f8bda77-5364-4902-9a98-208f1cdd7643",
             "images": [
                 {
@@ -321,12 +314,19 @@ is observed, in the event the track is paused the value will be ``1`` else it wi
                 }
             ],
             "name": "Showtime, Storytime",
-            "spotify_uri": "spotify:album:1tZlCjdI2dcfBXP8iSDsSI"
+            "uri": "spotify:album:1tZlCjdI2dcfBXP8iSDsSI"
         },
+        "artists": [
+            {
+                "id": "26556f7e-3304-4e51-8243-dd2199fcf6fa",
+                "name": "Nightwish",
+                "uri": "spotify:artist:2NPduAUeLVsfIauhRwuft1"
+            }
+        ],
         "duration": 272906,
         "id": "4b170737-017c-4e85-965c-47b8a158c789",
         "name": "Dark Chest Of Wonders - Live @ Wacken 2013",
-        "spotify_uri": "spotify:track:6FshvOVICpRVkwpYE5BYTD"
+        "uri": "spotify:track:6FshvOVICpRVkwpYE5BYTD"
     }
 
 
@@ -574,13 +574,6 @@ Returns a paginated list of tracks in no particular order.
     [
         {
             "album": {
-                "artists": [
-                    {
-                        "id": "26556f7e-3304-4e51-8243-dd2199fcf6fa",
-                        "name": "Nightwish",
-                        "spotify_uri": "spotify:artist:2NPduAUeLVsfIauhRwuft1"
-                    }
-                ],
                 "id": "7f8bda77-5364-4902-9a98-208f1cdd7643",
                 "images": [
                     {
@@ -600,12 +593,19 @@ Returns a paginated list of tracks in no particular order.
                     }
                 ],
                 "name": "Showtime, Storytime",
-                "spotify_uri": "spotify:album:1tZlCjdI2dcfBXP8iSDsSI"
+                "uri": "spotify:album:1tZlCjdI2dcfBXP8iSDsSI"
             },
+            "artists": [
+                {
+                    "id": "26556f7e-3304-4e51-8243-dd2199fcf6fa",
+                    "name": "Nightwish",
+                    "uri": "spotify:artist:2NPduAUeLVsfIauhRwuft1"
+                }
+            ],
             "duration": 272906,
             "id": "4b170737-017c-4e85-965c-47b8a158c789",
             "name": "Dark Chest Of Wonders - Live @ Wacken 2013",
-            "spotify_uri": "spotify:track:6FshvOVICpRVkwpYE5BYTD"
+            "uri": "spotify:track:6FshvOVICpRVkwpYE5BYTD"
         },
         ...
     ]
@@ -634,13 +634,6 @@ Returns the specific track object.
 
     {
         "album": {
-            "artists": [
-                {
-                    "id": "26556f7e-3304-4e51-8243-dd2199fcf6fa",
-                    "name": "Nightwish",
-                    "spotify_uri": "spotify:artist:2NPduAUeLVsfIauhRwuft1"
-                }
-            ],
             "id": "7f8bda77-5364-4902-9a98-208f1cdd7643",
             "images": [
                 {
@@ -660,12 +653,19 @@ Returns the specific track object.
                 }
             ],
             "name": "Showtime, Storytime",
-            "spotify_uri": "spotify:album:1tZlCjdI2dcfBXP8iSDsSI"
+            "uri": "spotify:album:1tZlCjdI2dcfBXP8iSDsSI"
         },
+        "artists": [
+            {
+                "id": "26556f7e-3304-4e51-8243-dd2199fcf6fa",
+                "name": "Nightwish",
+                "uri": "spotify:artist:2NPduAUeLVsfIauhRwuft1"
+            }
+        ],
         "duration": 272906,
         "id": "4b170737-017c-4e85-965c-47b8a158c789",
         "name": "Dark Chest Of Wonders - Live @ Wacken 2013",
-        "spotify_uri": "spotify:track:6FshvOVICpRVkwpYE5BYTD"
+        "uri": "spotify:track:6FshvOVICpRVkwpYE5BYTD"
     }
 
 .. |circle| image:: https://img.shields.io/circleci/project/thisissoon/FM-API/master.svg?style=flat

--- a/fm/serializers/spotify.py
+++ b/fm/serializers/spotify.py
@@ -12,6 +12,7 @@ import kim.types as t
 
 from kim.fields import Field
 from kim.contrib.sqa import SQASerializer
+from kim.roles import blacklist
 
 
 class ArtistSerializer(SQASerializer):
@@ -20,7 +21,7 @@ class ArtistSerializer(SQASerializer):
 
     id = Field(t.String, read_only=True)
     name = Field(t.String)
-    spotify_uri = Field(t.String)
+    uri = Field(t.String, source='spotify_uri')
 
 
 class AlbumSerializer(SQASerializer):
@@ -29,7 +30,7 @@ class AlbumSerializer(SQASerializer):
 
     id = Field(t.String, read_only=True)
     name = Field(t.String)
-    spotify_uri = Field(t.String)
+    uri = Field(t.String, source='spotify_uri')
     images = Field(t.BaseType)
 
     #
@@ -46,11 +47,14 @@ class TrackSerialzier(SQASerializer):
     id = Field(t.String, read_only=True)
     name = Field(t.String)
     duration = Field(t.Integer)
-    spotify_uri = Field(t.String)
+    uri = Field(t.String, source='spotify_uri')
     play_count = Field(t.Integer, read_only=True)
 
     #
     # Relations
     #
 
-    album = Field(t.Nested(AlbumSerializer))
+    album = Field(t.Nested(AlbumSerializer, role=blacklist('artists')))
+    artists = Field(t.Collection(
+        t.Nested(ArtistSerializer)),
+        source='album.artists')


### PR DESCRIPTION
As requested by the FE team this PR returns artists as part of the track serializer + renaming spotify_uri to uri to mimic the spotify API w/ Readme updates.

### Example Track Data

``` json
    [
        {
            "album": {
                "id": "7f8bda77-5364-4902-9a98-208f1cdd7643",
                "images": [
                    {
                        "height": 640,
                        "url": "https://i.scdn.co/image/7928fc9bd902b917aae0ef1bee41cb51598a2d27",
                        "width": 640
                    },
                    {
                        "height": 300,
                        "url": "https://i.scdn.co/image/e80cb4d324d16881e2f7653abdbd70497bbab68d",
                        "width": 300
                    },
                    {
                        "height": 64,
                        "url": "https://i.scdn.co/image/bf567406035a8e2b162c6a23470c6cdd5dd560f3",
                        "width": 64
                    }
                ],
                "name": "Showtime, Storytime",
                "uri": "spotify:album:1tZlCjdI2dcfBXP8iSDsSI"
            },
            "artists": [
                {
                    "id": "26556f7e-3304-4e51-8243-dd2199fcf6fa",
                    "name": "Nightwish",
                    "uri": "spotify:artist:2NPduAUeLVsfIauhRwuft1"
                }
            ],
            "duration": 272906,
            "id": "4b170737-017c-4e85-965c-47b8a158c789",
            "name": "Dark Chest Of Wonders - Live @ Wacken 2013",
            "uri": "spotify:track:6FshvOVICpRVkwpYE5BYTD"
        },
    ]
```