### PR TITLE
Feature: Event Listener

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,13 @@
-FROM debian:wheezy
+FROM debian:jessie
 
 ADD https://bootstrap.pypa.io/get-pip.py /get-pip.py
 
 RUN apt-get update && apt-get install -y \
         build-essential \
         git \
-        libpq-dev \
         python-dev \
+        libpq-dev \
+        libc6-dev \
         libevent-dev \
     && apt-get clean \
     && apt-get autoclean \
@@ -14,15 +15,15 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/{apt,dpkg,cache,log}/
 
 RUN chmod +x /get-pip.py
-RUN /get-pip.py
+RUN python /get-pip.py
+
+RUN pip install Cython==0.22
 
 WORKDIR /fm
-COPY . /fm
 
-RUN pip install -r install.reqs
+COPY . /fm
+RUN python setup.py install
 
 EXPOSE 5000
-
-RUN python setup.py install
 
 CMD gunicorn -b $GUNICORN_HOST:$GUNICORN_PORT -e FM_SETTINGS_MODULE=$FM_SETTINGS_MODULE -w $GUNICORN_WORKERS fm.wsgi:app

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ RUN apt-get update && apt-get install -y \
         git \
         libpq-dev \
         python-dev \
+        libevent-dev \
     && apt-get clean \
     && apt-get autoclean \
     && apt-get autoremove -y \

--- a/fm/events/listener.py
+++ b/fm/events/listener.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+"""
+fm.events.listener
+==================
+
+Redis Pub/Sub Service, listening on events from a Redis channel and
+handling events it cares about.
+"""
+
+import gevent
+import json
+
+
+from fm.ext import config, redis
+
+
+def handle_event(event):
+    """ Handles an event from the Redis Pubsub channel. If the event is one
+    we care about we will spawn a new Greenlet to handle the event asynchronously.
+
+    Argument
+    --------
+    event : dict
+        The event data
+    """
+
+    pass
+
+
+def listen(pubsub):
+    """ Listens for events on provided pubsub channel and spoawns other
+    greenlets to act on them.
+    """
+
+    for message in pubsub.listen():
+        if message['type'] == 'message':
+            data = json.loads(message['data'])
+            handle_event(data)
+
+
+def listener():
+    """ Redis event listener. Spawns a Gevent Greenlet which listens on the
+    redis pubsub channel.
+    """
+
+    pubsub = redis.pubsub()
+    pubsub.subscribe(config.PLAYER_CHANNEL)
+
+    gevent.spawn(listen, pubsub).join()

--- a/fm/manage.py
+++ b/fm/manage.py
@@ -8,11 +8,11 @@ fm.manage
 FM Management Command Scripts.
 """
 
+
 from gevent.monkey import patch_all
-patch_all()
+patch_all()  # noqa
 
-import alembic
-
+from alembic import command
 from flask.ext.migrate import Migrate, MigrateCommand, _get_config
 from flask.ext.script import Manager, Server, prompt_bool
 from fm import app
@@ -48,8 +48,8 @@ def reset():
         db.session.commit()
 
         config = _get_config(None)
-        alembic.command.stamp(config, 'base')
-        alembic.command.upgrade(config, 'head')
+        command.stamp(config, 'base')
+        command.upgrade(config, 'head')
 
 
 manager.add_command("runserver", Server(host='0.0.0.0'))

--- a/fm/manage.py
+++ b/fm/manage.py
@@ -8,17 +8,33 @@ fm.manage
 FM Management Command Scripts.
 """
 
+from gevent.monkey import patch_all
+patch_all()
+
 import alembic
 
 from flask.ext.migrate import Migrate, MigrateCommand, _get_config
 from flask.ext.script import Manager, Server, prompt_bool
 from fm import app
+from fm.events.listener import listener
 from fm.ext import db
+
 
 app = app.create()
 
 manager = Manager(app)
 migrate = Migrate(app, db)
+
+
+@manager.command
+def runeventlistener():
+    """ Run the Redis Event Listener. This will spawn a Gevent Greenlet.
+    """
+
+    try:
+        listener()
+    except KeyboardInterrupt:
+        print 'Exited'
 
 
 @MigrateCommand.command

--- a/install.reqs
+++ b/install.reqs
@@ -17,6 +17,7 @@ spotipy==2.3.0
 
 # Asynchronous
 celery==3.1.17
+gevent==1.0.1
 
 # Serialization
 py-kim==0.1.6

--- a/install.reqs
+++ b/install.reqs
@@ -17,7 +17,7 @@ spotipy==2.3.0
 
 # Asynchronous
 celery==3.1.17
-gevent==1.0.1
+gevent==1.0
 
 # Serialization
 py-kim==0.1.6

--- a/setup.py
+++ b/setup.py
@@ -100,6 +100,9 @@ setup(
     include_package_data=True,
     zip_safe=False,
     # Dependencies
+    dependency_links=[
+        'git+https://github.com/gevent/gevent.git@1.0.2#egg=gevent-1.0'
+    ],
     install_requires=INSTALL_REQS,
     extras_require={
         'develop': DEVELOP_REQS


### PR DESCRIPTION
This PR adds the ability for the API to run its own event listener. This will be needed for the API to directly listen for events and make changes to the DB and even publish events if needed.

Due to problems with Debian, SSL 3 and Gevent this now installs Gevent from Github which patches SSL3 out of Gevent.