### PR TITLE
Fix: Support Multiple Sessions

### DIFF
--- a/fm/session.py
+++ b/fm/session.py
@@ -60,7 +60,7 @@ def make_session(pk):
     session_id = serializer.dumps(pk)
 
     redis.set(SESSION_KEY.format(session_id), pk)
-    redis.set(USER_SESSION_KEY.format(pk), session_id)
+    redis.sadd(USER_SESSION_KEY.format(pk), session_id)
 
     return session_id
 

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -59,7 +59,7 @@ class TestMakeSession(object):
 
         assert make_session('1234') == 'foobar'
         redis.set.assert_has_call(SESSION_KEY.format('foobar'), '1234')
-        redis.set.assert_has_call(USER_SESSION_KEY.format('1234'), 'foobar')
+        redis.sadd.assert_has_call(USER_SESSION_KEY.format('1234'), 'foobar')
 
 
 class TestValidateSession(object):

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -74,13 +74,9 @@ class TestValidateSession(object):
 
         assert validate_session('foo') is None
 
-    def ensure_no_user_session_key_returns_none(self):
-        self.redis.get.side_effect = ['1234', None]
-
-        assert validate_session('foo') is None
-
-    def ensure_session_user_id_user_id_session_match(self):
-        self.redis.get.side_effect = ['1234', '4567']
+    def ensure_session_id_in_user_sessions(self):
+        self.redis.get.return_value = '1234',
+        self.redis.smembers.return_value = set(['4567'])
 
         assert validate_session('foo') is None
 
@@ -88,7 +84,8 @@ class TestValidateSession(object):
         serializer = URLSafeTimedSerializer(self.app.config['SECRET_KEY'])
         session_id = serializer.dumps('1234')
 
-        self.redis.get.side_effect = ['4567', session_id]
+        self.redis.get.return_value = '4567'
+        self.redis.smembers.return_value = set([session_id])
 
         assert validate_session(session_id) is None
 
@@ -96,7 +93,8 @@ class TestValidateSession(object):
         serializer = URLSafeTimedSerializer(self.app.config['SECRET_KEY'])
         session_id = serializer.dumps('1234')
 
-        self.redis.get.side_effect = ['1234', session_id]
+        self.redis.get.return_value = '1234'
+        self.redis.smembers.return_value = set([session_id])
 
         assert validate_session(session_id) is '1234'
 


### PR DESCRIPTION
The issues experienced yesterday with Florance and Ryan with authentication was due to logging in on multiple devices. The current sessions system only supports one session per user, thus session IDs would get overridden with each new login on a different device.

This PR fixes this problem by changing the users session storage from a string to a set allowing for multiple sessions to be stored against the user. 