### PR TITLE
Return elapsed time for current track

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -550,12 +550,15 @@ is observed, in the event the track is paused the value will be ``1`` else it wi
             "name": "Dark Chest Of Wonders - Live @ Wacken 2013",
             "uri": "spotify:track:6FshvOVICpRVkwpYE5BYTD"
         },
-        "user" {
+        "user": {
             "avatar_url": "https://lh5.googleusercontent.com/-8zjhd-e4yZA/AAAAAAAAAAI/AAAAAAAAAFU/NiS1oH4gAKo/photo.jpg",
             "display_name": "Chris Reeves",
             "family_name": "Reeves",
             "given_name": "Chris",
             "id": "8258be6b-ee53-4186-8bbd-55bc0a3a6f24"
+        },
+        "player": {
+            "elapsed_time": 5000
         }
     }
 

--- a/fig.yml
+++ b/fig.yml
@@ -1,5 +1,5 @@
 api:
-  image: soon/fm-api:develop
+  image: soon/fm-api
   command: ./manage.py runserver
   ports:
     - "5000:5000"
@@ -17,7 +17,7 @@ api:
     - REDIS_DB=0
     - ECHONEST_API_KEY=CIJ9BRHQVCOULALBX
 celery:
-  image: soon/fm-api:develop
+  image: soon/fm-api
   command: celery -A fm.tasks.app worker -l info -c 2
   links:
     - postgres

--- a/fm/views/player.py
+++ b/fm/views/player.py
@@ -182,7 +182,7 @@ class CurrentView(MethodView):
             'track': TrackSerializer().serialize(track),
             'user': UserSerializer().serialize(user),
             'player': {
-                'elapsed_time': redis.get('fm:player:elapsed_time') * 1000  # ms
+                'elapsed_time': int(redis.get('fm:player:elapsed_time')) * 1000  # ms
             }
         }
 

--- a/fm/views/player.py
+++ b/fm/views/player.py
@@ -178,10 +178,12 @@ class CurrentView(MethodView):
         headers = {
             'Paused': paused
         }
-
         response = {
             'track': TrackSerializer().serialize(track),
             'user': UserSerializer().serialize(user),
+            'player': {
+                'elapsed_time': redis.get('fm:player:elapsed_time') * 1000  # ms
+            }
         }
 
         return http.OK(response, headers=headers)

--- a/tests/views/player/test_current.py
+++ b/tests/views/player/test_current.py
@@ -78,7 +78,7 @@ class TestCurrentGet(BaseCurrentTest):
                 'uri': track.spotify_uri,
                 'user': user.id
             }),
-            'fm:player:elapsed_time': 5
+            'fm:player:elapsed_time': "5"
         }
         self.redis.get.side_effect = lambda x: mock_redis_values.get(x)
 

--- a/tests/views/player/test_current.py
+++ b/tests/views/player/test_current.py
@@ -73,10 +73,14 @@ class TestCurrentGet(BaseCurrentTest):
         db.session.add_all([track, user])
         db.session.commit()
 
-        self.redis.get.return_value = json.dumps({
-            'uri': track.spotify_uri,
-            'user': user.id
-        })
+        mock_redis_values = {
+            'fm:player:current': json.dumps({
+                'uri': track.spotify_uri,
+                'user': user.id
+            }),
+            'fm:player:elapsed_time': 5
+        }
+        self.redis.get.side_effect = lambda x: mock_redis_values.get(x)
 
         url = url_for('player.current')
         response = self.client.get(url)
@@ -84,6 +88,7 @@ class TestCurrentGet(BaseCurrentTest):
         assert response.status_code == 200
         assert response.json['track'] == TrackSerializer().serialize(track)
         assert response.json['user'] == UserSerializer().serialize(user)
+        assert response.json['player']['elapsed_time'] == 5000
 
 
 @pytest.mark.usefixtures("authenticated")


### PR DESCRIPTION
Current endpoint returns elapsed time of current track in ms. Elapsed time is pulled from Redis queue `fm:player:elapsed_time` where it's stored in seconds. 