### PR TITLE
Return updated objects in api

### DIFF
--- a/tests/views/player/test_current.py
+++ b/tests/views/player/test_current.py
@@ -116,7 +116,7 @@ class TestCurrentDelete(BaseCurrentTest):
         url = url_for('player.current')
         response = self.client.delete(url)
 
-        assert response.status_code == 204
+        assert response.status_code == 200
         self.redis.publish.assert_called_once_with(
             self.app.config.get('PLAYER_CHANNEL'),
             json.dumps({

--- a/tests/views/player/test_mute.py
+++ b/tests/views/player/test_mute.py
@@ -92,7 +92,7 @@ class TestDeleteMute(BaseMuteTest):
         url = url_for('player.mute')
         response = self.client.delete(url)
 
-        assert response.status_code == 204
+        assert response.status_code == 200
         self.redis.publish.assert_called_once_with(
             self.app.config.get('PLAYER_CHANNEL'),
             json.dumps({

--- a/tests/views/player/test_pause.py
+++ b/tests/views/player/test_pause.py
@@ -62,7 +62,7 @@ class TestPauseDelete(BasePauseTest):
         url = url_for('player.pause')
         response = self.client.delete(url)
 
-        assert response.status_code == 204
+        assert response.status_code == 200
         self.redis.publish.assert_called_once_with(
             self.app.config.get('PLAYER_CHANNEL'),
             json.dumps({

--- a/tests/views/player/test_volume.py
+++ b/tests/views/player/test_volume.py
@@ -87,3 +87,4 @@ class TestVolumePost(BaseVolumeTest):
                 'event': 'set_volume',
                 'volume': 20
             }))
+        assert response.json == {'volume': 20}


### PR DESCRIPTION
Return updated objects for player api. When DELETE is called and there are same data to be changed/deleted it should return `200`. `204` should be used when data on hit resource doesn't exists. 