### PR TITLE
When elapsed time doesn't exist in redis return 0

### DIFF
--- a/fm/views/player.py
+++ b/fm/views/player.py
@@ -175,6 +175,11 @@ class CurrentView(MethodView):
         except (ValueError, TypeError):
             paused = 0
 
+        try:
+            elapsed_time = int(redis.get('fm:player:elapsed_time')) * 1000  # ms
+        except (ValueError, TypeError):
+            elapsed_time = 0
+
         headers = {
             'Paused': paused
         }
@@ -182,7 +187,7 @@ class CurrentView(MethodView):
             'track': TrackSerializer().serialize(track),
             'user': UserSerializer().serialize(user),
             'player': {
-                'elapsed_time': int(redis.get('fm:player:elapsed_time')) * 1000  # ms
+                'elapsed_time': elapsed_time  # ms
             }
         }
 


### PR DESCRIPTION
Elapsed time value in Redis might be `None` and `int(None)` raises some exceptions..