### PR TITLE
Feature: New Elapsed Time Mechanic

### DIFF
--- a/fm/views/player.py
+++ b/fm/views/player.py
@@ -18,6 +18,7 @@ from datetime import datetime, timedelta
 
 # Third Party Libs
 import dateutil.parser
+import dateutil.tz
 import pytz
 from flask import request, url_for
 from flask.views import MethodView
@@ -192,6 +193,8 @@ class CurrentView(MethodView):
         """
 
         now = datetime.utcnow()
+        if now.tzinfo is None:
+            now = now.replace(tzinfo=dateutil.tz.tzutc())
 
         # Get play start time
         start_time = redis.get('fm:player:start_time')

--- a/fm/views/player.py
+++ b/fm/views/player.py
@@ -242,11 +242,6 @@ class CurrentView(MethodView):
         except (ValueError, TypeError):
             paused = 0
 
-        try:
-            elapsed_time = int(redis.get('fm:player:elapsed_time')) * 1000  # ms
-        except (ValueError, TypeError):
-            elapsed_time = 0
-
         headers = {
             'Paused': paused
         }
@@ -254,7 +249,7 @@ class CurrentView(MethodView):
             'track': TrackSerializer().serialize(track),
             'user': UserSerializer().serialize(user),
             'player': {
-                'elapsed_time': elapsed_time  # ms
+                'elapsed_time': self.elapsed(paused=bool(paused))  # MS
             }
         }
 

--- a/fm/views/player.py
+++ b/fm/views/player.py
@@ -179,7 +179,7 @@ class CurrentView(MethodView):
 
         return track, user
 
-    def elapsed(self):
+    def elapsed(self, paused=False):
         """ Calculates the current playhead (durration) of the track based on
         two factors, 1: Track Start Time, 2: Total Pause Durration.
 
@@ -205,6 +205,15 @@ class CurrentView(MethodView):
             pause_durration = int(redis.get('fm:player:pause_durration'))
         except (ValueError, TypeError):
             pause_durration = 0
+
+        # If we are in a puase state we also need to add on the difference
+        # between the pause start time and now to pause duration
+        paused_start = None
+        if paused:
+            paused_start = redis.get('fm:player:paused_start')
+            if paused_start is not None:
+                paused_start = dateutil.parser.parse(paused_start)
+                pause_durration += int((now - paused_start).total_seconds() * 1000)
 
         # Perform calculation
         diff = now - (start_time + timedelta(

--- a/fm/views/player.py
+++ b/fm/views/player.py
@@ -8,11 +8,13 @@ fm.views.player
 Views for handling /player API resource requests.
 """
 
+from __future__ import division
+
 # Standard Libs
 import itertools
 import json
 from collections import Counter
-from datetime import datetime
+from datetime import datetime, timedelta
 
 # Third Party Libs
 import dateutil.parser
@@ -181,7 +183,7 @@ class CurrentView(MethodView):
         """ Calculates the current playhead (durration) of the track based on
         two factors, 1: Track Start Time, 2: Total Pause Durration.
 
-        elapsed = (now - start) + paused
+        elapsed = (now - (start + paused))
 
         Returns
         -------
@@ -200,13 +202,15 @@ class CurrentView(MethodView):
 
         # Get Pause Durration
         try:
-            pause_durration = int(redis.get('fm:player:paused'))
+            pause_durration = int(redis.get('fm:player:pause_durration'))
         except (ValueError, TypeError):
             pause_durration = 0
 
         # Perform calculation
-        diff = now - start_time
-        elapsed = (int(diff.total_seconds() * 1000)) + pause_durration
+        diff = now - (start_time + timedelta(
+            seconds=pause_durration / 1000
+        ))
+        elapsed = int(diff.total_seconds() * 1000)
 
         return elapsed
 

--- a/fm/views/player.py
+++ b/fm/views/player.py
@@ -202,7 +202,7 @@ class CurrentView(MethodView):
 
         # Get Pause Durration
         try:
-            pause_durration = int(redis.get('fm:player:pause_durration'))
+            pause_durration = int(redis.get('fm:player:pause_duration'))
         except (ValueError, TypeError):
             pause_durration = 0
 
@@ -210,7 +210,7 @@ class CurrentView(MethodView):
         # between the pause start time and now to pause duration
         paused_start = None
         if paused:
-            paused_start = redis.get('fm:player:paused_start')
+            paused_start = redis.get('fm:player:pause_time')
             if paused_start is not None:
                 paused_start = dateutil.parser.parse(paused_start)
                 pause_durration += int((now - paused_start).total_seconds() * 1000)
@@ -242,6 +242,8 @@ class CurrentView(MethodView):
         except (ValueError, TypeError):
             paused = 0
 
+        elapsed = self.elapsed(paused=bool(paused))
+
         headers = {
             'Paused': paused
         }
@@ -249,7 +251,8 @@ class CurrentView(MethodView):
             'track': TrackSerializer().serialize(track),
             'user': UserSerializer().serialize(user),
             'player': {
-                'elapsed_time': self.elapsed(paused=bool(paused))  # MS
+                'elapsed_time': elapsed,  # ms
+                'elapsed_percentage': (elapsed / track.duration) * 100  # %
             }
         }
 

--- a/fm/views/player.py
+++ b/fm/views/player.py
@@ -255,7 +255,8 @@ class CurrentView(MethodView):
             'user': UserSerializer().serialize(user),
             'player': {
                 'elapsed_time': elapsed,  # ms
-                'elapsed_percentage': (elapsed / track.duration) * 100  # %
+                'elapsed_percentage': (elapsed / track.duration) * 100,  # %
+                'elapsed_seconds': elapsed / 1000  # seconds
             }
         }
 

--- a/tests/views/player/test_current.py
+++ b/tests/views/player/test_current.py
@@ -14,6 +14,7 @@ import json
 import uuid
 
 # Third Party Libs
+import dateutil.tz
 import mock
 import pytest
 from flask import url_for
@@ -76,8 +77,10 @@ class TestCalculateElapsed(BaseCurrentTest):
             assert CurrentView().elapsed() == 0
 
     def test_no_paused_durration(self):
-        now = datetime.datetime(2015, 1, 1, 13, 10, 2)
-        start_time = datetime.datetime(2015, 1, 1, 13, 10, 0)  # Started 2 seconds ago
+        tzutc = dateutil.tz.tzutc()
+        now = datetime.datetime(2015, 1, 1, 13, 10, 2, tzinfo=tzutc)
+        # Started 2 seconds ago
+        start_time = datetime.datetime(2015, 1, 1, 13, 10, 0, tzinfo=tzutc)
 
         self.redis.get.return_value = start_time.isoformat()
 
@@ -88,8 +91,10 @@ class TestCalculateElapsed(BaseCurrentTest):
             assert CurrentView().elapsed() == 2000
 
     def test_with_pause_durration(self):
-        now = datetime.datetime(2015, 1, 1, 13, 10, 23)  # now
-        start_time = datetime.datetime(2015, 1, 1, 13, 10, 0)  # started 22 seconds ago
+        tzutc = dateutil.tz.tzutc()
+        now = datetime.datetime(2015, 1, 1, 13, 10, 23, tzinfo=tzutc)  # now
+        # started 22 seconds ago
+        start_time = datetime.datetime(2015, 1, 1, 13, 10, 0, tzinfo=tzutc)
 
         # Paused for 20 seconds = 20000 ms
         self.redis.get.side_effect = [
@@ -104,9 +109,12 @@ class TestCalculateElapsed(BaseCurrentTest):
             assert CurrentView().elapsed() == 3000
 
     def test_in_live_pause_state(self):
-        now = datetime.datetime(2015, 1, 1, 13, 10, 32)  # now
-        start_time = datetime.datetime(2015, 1, 1, 13, 10, 0)  # started 32 seconds ago
-        pause_start = datetime.datetime(2015, 1, 1, 13, 10, 23)   # 3 seconds of play
+        tzutc = dateutil.tz.tzutc()
+        now = datetime.datetime(2015, 1, 1, 13, 10, 32, tzinfo=tzutc)
+        # started 32 seconds ago
+        start_time = datetime.datetime(2015, 1, 1, 13, 10, 0, tzinfo=tzutc)
+        # 3 seconds of play
+        pause_start = datetime.datetime(2015, 1, 1, 13, 10, 23, tzinfo=tzutc)
 
         # Paused for 20 seconds = 20000 ms
         self.redis.get.side_effect = [
@@ -133,6 +141,7 @@ class TestCurrentGet(BaseCurrentTest):
 
         now = datetime.datetime.utcnow()
         start = now - datetime.timedelta(seconds=5)
+        start = start.replace(tzinfo=dateutil.tz.tzutc())
 
         mock_redis_values = {
             'fm:player:current': json.dumps({

--- a/tests/views/player/test_current.py
+++ b/tests/views/player/test_current.py
@@ -125,7 +125,7 @@ class TestCalculateElapsed(BaseCurrentTest):
 class TestCurrentGet(BaseCurrentTest):
 
     def should_return_track_data(self):
-        track = TrackFactory()
+        track = TrackFactory(duration=10000)
         user = UserFactory()
 
         db.session.add_all([track, user])
@@ -154,6 +154,7 @@ class TestCurrentGet(BaseCurrentTest):
         assert response.json['track'] == TrackSerializer().serialize(track)
         assert response.json['user'] == UserSerializer().serialize(user)
         assert response.json['player']['elapsed_time'] == 5000
+        assert response.json['player']['elapsed_percentage'] == 50
 
     def should_return_zero_when_elapsed_time_cant_be_pulled(self):
         track = TrackFactory()
@@ -178,6 +179,7 @@ class TestCurrentGet(BaseCurrentTest):
         assert response.json['track'] == TrackSerializer().serialize(track)
         assert response.json['user'] == UserSerializer().serialize(user)
         assert response.json['player']['elapsed_time'] == 0
+        assert response.json['player']['elapsed_percentage'] == 0
 
 
 @pytest.mark.usefixtures("authenticated")

--- a/tests/views/player/test_current.py
+++ b/tests/views/player/test_current.py
@@ -164,6 +164,7 @@ class TestCurrentGet(BaseCurrentTest):
         assert response.json['user'] == UserSerializer().serialize(user)
         assert response.json['player']['elapsed_time'] == 5000
         assert response.json['player']['elapsed_percentage'] == 50
+        assert response.json['player']['elapsed_seconds'] == 5
 
     def should_return_zero_when_elapsed_time_cant_be_pulled(self):
         track = TrackFactory()
@@ -189,6 +190,7 @@ class TestCurrentGet(BaseCurrentTest):
         assert response.json['user'] == UserSerializer().serialize(user)
         assert response.json['player']['elapsed_time'] == 0
         assert response.json['player']['elapsed_percentage'] == 0
+        assert response.json['player']['elapsed_seconds'] == 0
 
 
 @pytest.mark.usefixtures("authenticated")


### PR DESCRIPTION
This PR implements a hopefully more accurate elapsed time mechanic.

Instead of ticking every second to redis we will store time stamp and durations in redis allowing the API to calculate a more accurate elapsed time figure.

We will now need to store:

- Play Start Time
- Pause Start Time (of the current live pause)
- Paused Duration (the total amount of pause time we have had in ms)

This allows us to calculate elapsed time as:

```
elapsed = (now - (start_time + (total_paused_time + (now - paused_start)))
```

The unittests should hopefully explain it better.

I've done this because ticking to redis every second from the player is unreliable and we seem to incur drift where the elapsed time stored in redis was not the actual elapsed time, this is probably due to the time it takes for the update to be made in redis each second so we would end up drifting from the real elapsed time.

Using stamps and tallies should give us much more accurate data.

I've also included a new `elapsed_percentage` in the response body, might be useful for the FE and debugging.