### PR TITLE
Feature/remove track from queue

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -366,9 +366,24 @@ album and artist nested objects.
                 "given_name": "Chris",
                 "id": "8258be6b-ee53-4186-8bbd-55bc0a3a6f24"
             }
+            "uuid": "16fd2706-8baf-433b-82eb-8c7fada847da"
         }
         ...
     ]
+
+``DELETE``
+^^^^^^^^^^
+
+Remove a track from the queue:
+
+http DELETE http://localhost/player/queue/
+
+    {
+        "uri": "spotify:track:6FshvOVICpRVkwpYE5BYTD",
+        "id": "8258be6b-ee53-4186-8bbd-55bc0a3a6f24",
+        "uuid": "16fd2706-8baf-433b-82eb-8c7fada847da"
+    }
+
 
 ``/player/queue/meta``
 ~~~~~~~~~~~~~~~~~~

--- a/fm/app.py
+++ b/fm/app.py
@@ -12,7 +12,7 @@ Flask Application Factory for bootstraping the FM API Application.
 import os
 import traceback
 
-# Third Pary Libs
+# Third Party Libs
 from flask import Flask, request
 
 # First Party Libs

--- a/fm/db/model.py
+++ b/fm/db/model.py
@@ -13,7 +13,6 @@ import datetime
 
 # Third Party Libs
 from dateutil.tz import tzutc
-# Third Pary Libs
 from flask.ext.sqlalchemy import Model
 from sqlalchemy import Column
 

--- a/fm/db/model.py
+++ b/fm/db/model.py
@@ -11,12 +11,13 @@ SQLAlchemy models.
 # Standard Libs
 import datetime
 
+# Third Party Libs
+from dateutil.tz import tzutc
 # Third Pary Libs
 from flask.ext.sqlalchemy import Model
 from sqlalchemy import Column
 
 # First Party Libs
-from dateutil.tz import tzutc
 from fm.db.types import UTCDateTime
 
 

--- a/fm/db/nosql.py
+++ b/fm/db/nosql.py
@@ -11,6 +11,7 @@ Classes for connecting to NoSQL data stores.
 # Standard Libs
 import urlparse
 
+# Third Party Libs
 # Third Pary Libs
 from redis import StrictRedis
 

--- a/fm/db/nosql.py
+++ b/fm/db/nosql.py
@@ -12,7 +12,6 @@ Classes for connecting to NoSQL data stores.
 import urlparse
 
 # Third Party Libs
-# Third Pary Libs
 from redis import StrictRedis
 
 

--- a/fm/db/sqla.py
+++ b/fm/db/sqla.py
@@ -7,8 +7,7 @@ fm.fb.sqla
 
 Custom SQLAlchemy functionality.
 """
-
-# Third Pary Libs
+# Third Party Libs
 from flask.ext.sqlalchemy import (
     SQLAlchemy,
     _BoundDeclarativeMeta,

--- a/fm/db/types.py
+++ b/fm/db/types.py
@@ -13,7 +13,6 @@ from datetime import datetime
 
 # Third Party Libs
 from dateutil.tz import tzutc
-# Third Pary Libs
 from sqlalchemy import types
 
 

--- a/fm/db/types.py
+++ b/fm/db/types.py
@@ -11,11 +11,10 @@ Custom types for SQLAlchemy models.
 # Standard Libs
 from datetime import datetime
 
+# Third Party Libs
+from dateutil.tz import tzutc
 # Third Pary Libs
 from sqlalchemy import types
-
-# First Party Libs
-from dateutil.tz import tzutc
 
 
 class UTCDateTime(types.TypeDecorator):

--- a/fm/events/listener.py
+++ b/fm/events/listener.py
@@ -12,7 +12,7 @@ handling events it cares about.
 # Standard Libs
 import json
 
-# Third Pary Libs
+# Third Party Libs
 import gevent
 from gevent.monkey import patch_all
 

--- a/fm/ext.py
+++ b/fm/ext.py
@@ -7,8 +7,7 @@ fm.ext
 
 Flask Application Extension Instantiation.
 """
-
-# Third Pary Libs
+# Third Party Libs
 from flask.ext.via import Via
 from werkzeug import LocalProxy
 

--- a/fm/http/cors.py
+++ b/fm/http/cors.py
@@ -7,8 +7,7 @@ fm.http.cors
 
 Cross Origin Request Handling.
 """
-
-# Third Pary Libs
+# Third Party Libs
 from flask import request
 
 

--- a/fm/http/pagination.py
+++ b/fm/http/pagination.py
@@ -12,7 +12,7 @@ Helper classes for constructing paginated responses.
 from functools import wraps
 from math import ceil
 
-# Third Pary Libs
+# Third Party Libs
 from flask import request
 from furl import furl
 from webargs import Arg

--- a/fm/logic/player.py
+++ b/fm/logic/player.py
@@ -7,8 +7,9 @@ generating random content.
 
 # Standard Libs
 import json
+import uuid
 
-# Third Pary Libs
+# Third Party Libs
 from sqlalchemy.sql import func
 
 # First Party Libs
@@ -39,7 +40,8 @@ class Queue(object):
             config.PLAYLIST_REDIS_KEY,
             json.dumps({
                 'uri': uri,
-                'user': user
+                'user': user,
+                'uuid': str(uuid.uuid4()),
             })
         )
 

--- a/fm/logic/player.py
+++ b/fm/logic/player.py
@@ -57,9 +57,7 @@ class Queue(object):
         if limit is None:
             limit = Queue.length()
 
-        tracks = redis.lrange(
-            config.PLAYLIST_REDIS_KEY, offset, (offset + limit - 1)
-        )
+        tracks = redis.lrange(config.PLAYLIST_REDIS_KEY, offset, (offset + limit - 1))
         return (json.loads(track) for track in tracks)
 
     @staticmethod
@@ -91,6 +89,29 @@ class Queue(object):
         """
 
         return redis.llen(config.PLAYLIST_REDIS_KEY)
+
+    @staticmethod
+    def delete(uri, user, uuid):
+        """ Remove a track from a redis queue
+
+        Parameters
+        ----------
+        uri: str
+            The spotify URI of the Track to add to the Queue
+        user: User model
+            The User class instance of the user whome added the track to the Queue
+        uuid: Uuid
+            Unique identifator of track in the queue
+        """
+        deleted = redis.lrem(
+            key=config.PLAYLIST_REDIS_KEY,
+            value=json.dumps({'uri': uri, 'user': user.id, 'uuid': uuid}),
+            count=1
+        )
+        if deleted >= 1:
+            return deleted
+        else:
+            raise ValueError('Cannot find value')
 
 
 class Random(object):

--- a/fm/logic/player.py
+++ b/fm/logic/player.py
@@ -109,6 +109,12 @@ class Queue(object):
             count=1
         )
         if deleted >= 1:
+            redis.publish(config.PLAYER_CHANNEL, json.dumps({
+                'event': 'deleted',
+                'uri': uri,
+                'user': user.id
+            }))
+
             return deleted
         else:
             raise ValueError('Cannot find value')

--- a/fm/models/spotify.py
+++ b/fm/models/spotify.py
@@ -12,7 +12,6 @@ Models for storing Spotify Track data.
 import uuid
 
 # Third Party Libs
-# Third Pary Libs
 from sqlalchemy import Index, func
 from sqlalchemy.dialects.postgresql import JSON, UUID
 from sqlalchemy.ext.associationproxy import association_proxy

--- a/fm/models/user.py
+++ b/fm/models/user.py
@@ -11,7 +11,7 @@ SQLAlchemy User Models.
 # Standard Libs
 import uuid
 
-# Third Pary Libs
+# Third Party Libs
 from sqlalchemy.dialects.postgresql import JSON, UUID
 
 # First Party Libs

--- a/fm/oauth2/google.py
+++ b/fm/oauth2/google.py
@@ -7,8 +7,7 @@ fm.oauth2.google
 
 Google oAuth2 Connection helper methods.
 """
-
-# Third Pary Libs
+# Third Party Libs
 import apiclient
 import httplib2
 from oauth2client.client import FlowExchangeError, credentials_from_code

--- a/fm/oauth2/spotify.py
+++ b/fm/oauth2/spotify.py
@@ -10,7 +10,7 @@ Spotify oAuth2 Connection helper methods.
 # Standard Libs
 import httplib
 
-# Third Pary Libs
+# Third Party Libs
 import requests
 from flask import url_for
 

--- a/fm/routes/oauth2.py
+++ b/fm/routes/oauth2.py
@@ -7,8 +7,7 @@ fm.routes.oauth2
 
 Routes for the Google OAUTH2 Authentication
 """
-
-# Third Pary Libs
+# Third Party Libs
 from flask.ext.via.routers.default import Pluggable
 
 # First Party Libs

--- a/fm/routes/root.py
+++ b/fm/routes/root.py
@@ -8,8 +8,7 @@ fm.routes.root
 Base routes for the FM application using Flask-Via.
 """
 
-
-# Third Pary Libs
+# Third Party Libs
 from flask.ext.via.routers import Include
 from flask.ext.via.routers.default import Pluggable
 

--- a/fm/routes/track.py
+++ b/fm/routes/track.py
@@ -8,8 +8,7 @@ fm.routes.track
 Routes for handling Tracks.
 """
 
-
-# Third Pary Libs
+# Third Party Libs
 from flask.ext.via.routers.default import Pluggable
 
 # First Party Libs

--- a/fm/routes/user.py
+++ b/fm/routes/user.py
@@ -8,8 +8,7 @@ fm.user.routes
 Routes for the User Views
 """
 
-
-# Third Pary Libs
+# Third Party Libs
 from flask.ext.via.routers.default import Pluggable
 
 # First Party Libs

--- a/fm/serializers/player.py
+++ b/fm/serializers/player.py
@@ -7,8 +7,7 @@ fm.serializers.player
 
 Marshmallow schemas for player resources.
 """
-
-# Third Pary Libs
+# Third Party Libs
 import kim.types as t
 from kim.exceptions import ValidationError
 from kim.fields import Field

--- a/fm/serializers/spotify.py
+++ b/fm/serializers/spotify.py
@@ -7,8 +7,7 @@ fm.serializers.spotify
 
 Kim serializers for `fm.models.spotify` models.
 """
-
-# Third Pary Libs
+# Third Party Libs
 import kim.types as t
 from kim.contrib.sqa import SQASerializer
 from kim.fields import Field

--- a/fm/serializers/types/spotify.py
+++ b/fm/serializers/types/spotify.py
@@ -11,14 +11,14 @@ Custom Kim Field Types relating to Spotifu Validation
 # Standard Libs
 import httplib
 
-# Third Pary Libs
+# Third Party Libs
+import requests
 from flask import url_for
 from kim import types as t
 from kim.exceptions import ValidationError
 from simplejson import JSONDecodeError
 
 # First Party Libs
-import requests
 from fm.models.user import User
 
 

--- a/fm/serializers/user.py
+++ b/fm/serializers/user.py
@@ -8,8 +8,7 @@ fm.user.serializer
 User Kim Serializers
 """
 
-
-# Third Pary Libs
+# Third Party Libs
 import kim.types as t
 from kim.fields import Field
 from kim.serializers import Serializer

--- a/fm/session.py
+++ b/fm/session.py
@@ -12,7 +12,7 @@ header.
 # Standard Libs
 from functools import wraps
 
-# Third Pary Libs
+# Third Party Libs
 from flask import g, has_request_context, request
 from itsdangerous import URLSafeTimedSerializer
 from werkzeug import LocalProxy

--- a/fm/thirdparty/echonest.py
+++ b/fm/thirdparty/echonest.py
@@ -11,12 +11,13 @@ Echo Nest Functions for retrieving data from Echo Nest API.
 # Standard Libs
 import httplib
 
+# Third Party Libs
+import requests
 # Third Pary Libs
 from furl import furl
 from simplejson import JSONDecodeError
 
 # First Party Libs
-import requests
 from fm.ext import config
 
 

--- a/fm/thirdparty/echonest.py
+++ b/fm/thirdparty/echonest.py
@@ -13,7 +13,6 @@ import httplib
 
 # Third Party Libs
 import requests
-# Third Pary Libs
 from furl import furl
 from simplejson import JSONDecodeError
 

--- a/fm/thirdparty/spotify.py
+++ b/fm/thirdparty/spotify.py
@@ -4,7 +4,7 @@
 # Standard Libs
 import httplib
 
-# Third Pary Libs
+# Third Party Libs
 import requests
 from flask import url_for
 from kim import types as t

--- a/fm/views/oauth2.py
+++ b/fm/views/oauth2.py
@@ -11,7 +11,7 @@ Views for the Google OAUTH2 authentication.
 # Standard Libs
 import json
 
-# Third Pary Libs
+# Third Party Libs
 from flask import current_app, render_template, request, url_for
 from flask.views import MethodView
 from furl import furl

--- a/fm/views/player.py
+++ b/fm/views/player.py
@@ -448,7 +448,8 @@ class QueueView(MethodView):
                 if track is not None and user is not None:
                     response.append({
                         'track': TrackSerializer().serialize(track),
-                        'user': UserSerializer().serialize(user)
+                        'user': UserSerializer().serialize(user),
+                        'uuid': item.get('uuid', None),
                     })
 
         return http.OK(

--- a/fm/views/player.py
+++ b/fm/views/player.py
@@ -477,6 +477,15 @@ class QueueView(MethodView):
             'tracks.track',
             pk_or_uri=track['uri']['uri']))
 
+    @authenticated
+    def delete(self):
+        data = request.json
+        try:
+            Queue.delete(uri=data['uri'], user=current_user, uuid=data['uuid'])
+        except ValueError:
+            return http.NoContent()
+        return http.OK()
+
 
 class QueueMetaView(MethodView):
 

--- a/fm/views/track.py
+++ b/fm/views/track.py
@@ -11,7 +11,7 @@ Track resources.
 # Standard Libs
 import uuid
 
-# Third Pary Libs
+# Third Party Libs
 from flask.views import MethodView
 
 # First Party Libs

--- a/fm/views/user.py
+++ b/fm/views/user.py
@@ -18,10 +18,13 @@ from flask.views import MethodView
 from fm import http
 from fm.logic.oauth import update_spotify_credentials
 from fm.models.user import User
-from fm.thirdparty.spotify import PlaylistSerializer, TrackSerializer
 from fm.serializers.user import UserSerializer
 from fm.session import authenticated, current_user
-from fm.thirdparty.spotify import SpotifyApi
+from fm.thirdparty.spotify import (
+    PlaylistSerializer,
+    SpotifyApi,
+    TrackSerializer
+)
 
 
 class UserAuthenticatedView(MethodView):

--- a/fm/views/user.py
+++ b/fm/views/user.py
@@ -11,7 +11,7 @@ Views for working with User objects.
 # Standard Libs
 import uuid
 
-# Third Pary Libs
+# Third Party Libs
 from flask.views import MethodView
 
 # First Party Libs

--- a/manage.py
+++ b/manage.py
@@ -7,8 +7,7 @@ fm.manage
 
 FM Management Command Scripts.
 """
-
-# Third Pary Libs
+# Third Party Libs
 import alembic
 from flask.ext.migrate import Migrate, MigrateCommand, _get_config
 from flask.ext.script import Manager, prompt_bool

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -3,7 +3,7 @@ from __future__ import with_statement
 # Standard Libs
 from logging.config import fileConfig
 
-# Third Pary Libs
+# Third Party Libs
 from alembic import context
 # add your model's MetaData object here
 # for 'autogenerate' support

--- a/migrations/versions/18a9779b6cc1_genre_artist_association.py
+++ b/migrations/versions/18a9779b6cc1_genre_artist_association.py
@@ -9,8 +9,7 @@ Create Date: 2015-04-17 14:57:41.825041
 # revision identifiers, used by Alembic.
 revision = '18a9779b6cc1'
 down_revision = 'de29e20a272'
-
-# Third Pary Libs
+# Third Party Libs
 import sqlalchemy as sa  # noqa
 from alembic import op  # noqa
 from sqlalchemy.dialects import postgresql

--- a/migrations/versions/1ff261e9610e_added_user_id_field_to_playerhistory_.py
+++ b/migrations/versions/1ff261e9610e_added_user_id_field_to_playerhistory_.py
@@ -9,8 +9,7 @@ Create Date: 2015-03-27 08:46:36.599337
 # revision identifiers, used by Alembic.
 revision = '1ff261e9610e'
 down_revision = '3da945eb68a1'
-
-# Third Pary Libs
+# Third Party Libs
 import sqlalchemy as sa  # noqa
 from alembic import op  # noqa
 from sqlalchemy.dialects import postgresql

--- a/migrations/versions/219d09e1a415_initial_spotify_tables.py
+++ b/migrations/versions/219d09e1a415_initial_spotify_tables.py
@@ -9,8 +9,7 @@ Create Date: 2015-03-02 15:19:53.409121
 # revision identifiers, used by Alembic.
 revision = '219d09e1a415'
 down_revision = None
-
-# Third Pary Libs
+# Third Party Libs
 import sqlalchemy as sa  # noqa
 from alembic import op  # noqa
 from sqlalchemy.dialects import postgresql

--- a/migrations/versions/2937e25e93cd_renaming_spotify_id_to_spotify_uri.py
+++ b/migrations/versions/2937e25e93cd_renaming_spotify_id_to_spotify_uri.py
@@ -9,8 +9,7 @@ Create Date: 2015-03-03 16:59:38.501727
 # revision identifiers, used by Alembic.
 revision = '2937e25e93cd'
 down_revision = '219d09e1a415'
-
-# Third Pary Libs
+# Third Party Libs
 import sqlalchemy as sa  # noqa
 from alembic import op  # noqa
 

--- a/migrations/versions/346114c5f61a_oauth2_credential_storage.py
+++ b/migrations/versions/346114c5f61a_oauth2_credential_storage.py
@@ -9,8 +9,7 @@ Create Date: 2015-03-06 14:56:54.257106
 # revision identifiers, used by Alembic.
 revision = '346114c5f61a'
 down_revision = '5af293f26813'
-
-# Third Pary Libs
+# Third Party Libs
 import sqlalchemy as sa  # noqa
 from alembic import op  # noqa
 from sqlalchemy.dialects import postgresql

--- a/migrations/versions/3a1d436efee7_spotify_added_into_user_account.py
+++ b/migrations/versions/3a1d436efee7_spotify_added_into_user_account.py
@@ -9,8 +9,7 @@ Create Date: 2015-04-02 14:21:06.190954
 # revision identifiers, used by Alembic.
 revision = '3a1d436efee7'
 down_revision = '1ff261e9610e'
-
-# Third Pary Libs
+# Third Party Libs
 import sqlalchemy as sa  # noqa
 from alembic import op  # noqa
 from sqlalchemy.dialects import postgresql

--- a/migrations/versions/3da945eb68a1_new_playlist_history_model.py
+++ b/migrations/versions/3da945eb68a1_new_playlist_history_model.py
@@ -9,8 +9,7 @@ Create Date: 2015-03-23 12:13:18.582809
 # revision identifiers, used by Alembic.
 revision = '3da945eb68a1'
 down_revision = '346114c5f61a'
-
-# Third Pary Libs
+# Third Party Libs
 import sqlalchemy as sa  # noqa
 from alembic import op  # noqa
 from sqlalchemy.dialects import postgresql

--- a/migrations/versions/491f96ede5d0_add_plays_field_to_track_model.py
+++ b/migrations/versions/491f96ede5d0_add_plays_field_to_track_model.py
@@ -9,8 +9,7 @@ Create Date: 2015-03-17 18:59:00.363547
 # revision identifiers, used by Alembic.
 revision = '491f96ede5d0'
 down_revision = '8778ad8a7ab'
-
-# Third Pary Libs
+# Third Party Libs
 import sqlalchemy as sa  # noqa
 from alembic import op  # noqa
 

--- a/migrations/versions/5af293f26813_user_model.py
+++ b/migrations/versions/5af293f26813_user_model.py
@@ -9,8 +9,7 @@ Create Date: 2015-03-06 14:26:27.380921
 # revision identifiers, used by Alembic.
 revision = '5af293f26813'
 down_revision = '491f96ede5d0'
-
-# Third Pary Libs
+# Third Party Libs
 import sqlalchemy as sa  # noqa
 from alembic import op  # noqa
 from sqlalchemy.dialects import postgresql

--- a/migrations/versions/8778ad8a7ab_added_images_field_to_album_model.py
+++ b/migrations/versions/8778ad8a7ab_added_images_field_to_album_model.py
@@ -9,8 +9,7 @@ Create Date: 2015-03-03 18:01:29.738011
 # revision identifiers, used by Alembic.
 revision = '8778ad8a7ab'
 down_revision = '2937e25e93cd'
-
-# Third Pary Libs
+# Third Party Libs
 import sqlalchemy as sa  # noqa
 from alembic import op  # noqa
 from sqlalchemy.dialects import postgresql

--- a/migrations/versions/de29e20a272_new_genre_model.py
+++ b/migrations/versions/de29e20a272_new_genre_model.py
@@ -9,8 +9,7 @@ Create Date: 2015-04-17 14:49:43.388383
 # revision identifiers, used by Alembic.
 revision = 'de29e20a272'
 down_revision = '3a1d436efee7'
-
-# Third Pary Libs
+# Third Party Libs
 import sqlalchemy as sa  # noqa
 from alembic import op  # noqa
 from sqlalchemy.dialects import postgresql

--- a/setup.py
+++ b/setup.py
@@ -15,10 +15,12 @@ import multiprocessing  # noqa
 import os
 import sys
 
-# First Party Libs
-import fm  # noqa
+# Third Party Libs
 from setuptools import find_packages, setup
 from setuptools.command.test import test as TestCommand
+
+# First Party Libs
+import fm  # noqa
 
 
 root = os.path.abspath(os.path.join(os.path.dirname(__file__)))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,14 +11,14 @@ PyTest Configuration
 # Standard Libs
 import json
 
-# Third Pary Libs
+# Third Party Libs
 import pytest
 from flask import g
+from tests.factories.user import UserFactory
 
 # First Party Libs
 from fm.app import create
 from fm.ext import db as _db
-from tests.factories.user import UserFactory
 
 
 _app = create()  # Create Application Instance

--- a/tests/factories/spotify.py
+++ b/tests/factories/spotify.py
@@ -11,7 +11,7 @@ SQLAlchemy Factories for Spotify models.
 # Standard Libs
 from datetime import datetime
 
-# Third Pary Libs
+# Third Party Libs
 import factory
 from dateutil import tz
 from factory import fuzzy

--- a/tests/factories/user.py
+++ b/tests/factories/user.py
@@ -11,13 +11,13 @@ SQLAlchemy Factories for User models.
 # Standard Libs
 import json
 
-# Third Pary Libs
+# Third Party Libs
 import factory
 from factory import fuzzy
+from tests.factories import UUID4, Factory
 
 # First Party Libs
 from fm.models.user import User
-from tests.factories import UUID4, Factory
 
 
 class UserFactory(Factory):

--- a/tests/logic/test_queue.py
+++ b/tests/logic/test_queue.py
@@ -1,15 +1,15 @@
 # Standard Libs
 import unittest
 
-# Third Pary Libs
+# Third Party Libs
 import mock
 from mockredis import mock_redis_client
+from tests.factories.spotify import TrackFactory
+from tests.factories.user import UserFactory
 
 # First Party Libs
 from fm.ext import db
 from fm.logic.player import Queue
-from tests.factories.spotify import TrackFactory
-from tests.factories.user import UserFactory
 
 
 @mock.patch('fm.logic.player.redis', mock_redis_client())

--- a/tests/logic/test_random.py
+++ b/tests/logic/test_random.py
@@ -1,10 +1,12 @@
 # Standard Libs
 import unittest
 
+# Third Party Libs
+from tests.factories.spotify import TrackFactory
+
 # First Party Libs
 from fm.ext import db
 from fm.logic.player import Random
-from tests.factories.spotify import TrackFactory
 
 
 class TestQueue(unittest.TestCase):

--- a/tests/serializers/types/test_spotify.py
+++ b/tests/serializers/types/test_spotify.py
@@ -11,16 +11,16 @@ Unit tests for sptoify Serializer field types.
 # Standard Libs
 import httplib
 
-# Third Pary Libs
+# Third Party Libs
 import mock
 import pytest
 import requests
 from kim.exceptions import ValidationError
 from simplejson import JSONDecodeError
+from tests import TRACK_DATA
 
 # First Party Libs
 from fm.serializers.types.spotify import SpotifyURI
-from tests import TRACK_DATA
 
 
 class TestSpotifyURI(object):

--- a/tests/tasks/test_artist.py
+++ b/tests/tasks/test_artist.py
@@ -11,15 +11,15 @@ Unittests for Artist Celery Tasks.
 # Standard Libs
 import uuid
 
-# Third Pary Libs
+# Third Party Libs
 import mock
+from tests.factories.spotify import ArtistFactory
 
 # First Party Libs
 from fm.ext import db
 from fm.models.spotify import Artist, Genre
 from fm.tasks.artist import update_genres
 from fm.thirdparty.echonest import EchoNestError
-from tests.factories.spotify import ArtistFactory
 
 
 class TestUpdateGenres(object):

--- a/tests/tasks/test_queue.py
+++ b/tests/tasks/test_queue.py
@@ -11,18 +11,18 @@ Unit Tests for Celery Queue Tasks
 # Standard Libs
 import json
 
-# Third Pary Libs
+# Third Party Libs
 import mock
 from mockredis import mock_redis_client
+from tests import TRACK_DATA
+from tests.factories.spotify import AlbumFactory, ArtistFactory, TrackFactory
+from tests.factories.user import UserFactory
 
 # First Party Libs
 from fm.ext import config, db
 from fm.models.spotify import Album, Artist, Track
 from fm.models.user import User
 from fm.tasks.queue import add
-from tests import TRACK_DATA
-from tests.factories.spotify import AlbumFactory, ArtistFactory, TrackFactory
-from tests.factories.user import UserFactory
 
 
 class TestAdd(object):

--- a/tests/test_echonest.py
+++ b/tests/test_echonest.py
@@ -11,15 +11,15 @@ Unittests for Echonest API communication functions.
 # Standard Libs
 import httplib
 
-# Third Pary Libs
+# Third Party Libs
 import mock
 import pytest
+import requests
 from simplejson import JSONDecodeError
+from tests import ECHONEST_ARTIST_GENRES
 
 # First Party Libs
-import requests
 from fm.thirdparty.echonest import EchoNestError, get_artist_genres
-from tests import ECHONEST_ARTIST_GENRES
 
 
 class TestGetArtistGenres(object):

--- a/tests/test_google.py
+++ b/tests/test_google.py
@@ -9,6 +9,7 @@ Tests for Google OAuth2 helpers.
 """
 
 # Third Pary Libs
+# Third Party Libs
 import mock
 import pytest
 from oauth2client.client import FlowExchangeError

--- a/tests/test_google.py
+++ b/tests/test_google.py
@@ -7,8 +7,6 @@ tests.test_google
 
 Tests for Google OAuth2 helpers.
 """
-
-# Third Pary Libs
 # Third Party Libs
 import mock
 import pytest

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -11,10 +11,11 @@ Unit tests for session management.
 # Standard Libs
 import uuid
 
-# Third Pary Libs
+# Third Party Libs
 import mock
 from flask import g
 from itsdangerous import URLSafeTimedSerializer
+from tests.factories.user import UserFactory
 
 # First Party Libs
 from fm.ext import db
@@ -27,7 +28,6 @@ from fm.session import (
     user_from_session,
     validate_session
 )
-from tests.factories.user import UserFactory
 
 
 class TestAuthenticated(object):

--- a/tests/views/oauth2/test_google_connect.py
+++ b/tests/views/oauth2/test_google_connect.py
@@ -11,7 +11,7 @@ Unit tests for the ``fm.views.oauth2.GoogleConnectView`` class.
 # Standard Libs
 import json
 
-# Third Pary Libs
+# Third Party Libs
 import mock
 from flask import url_for
 

--- a/tests/views/oauth2/test_spotify_conect.py
+++ b/tests/views/oauth2/test_spotify_conect.py
@@ -12,7 +12,7 @@ import httplib
 import json
 import urllib
 
-# Third Pary Libs
+# Third Party Libs
 import mock
 import pytest
 from flask import g, url_for

--- a/tests/views/player/test_current.py
+++ b/tests/views/player/test_current.py
@@ -18,14 +18,14 @@ import dateutil.tz
 import mock
 import pytest
 from flask import url_for
+from tests.factories.spotify import TrackFactory
+from tests.factories.user import UserFactory
 
 # First Party Libs
 from fm.ext import db
 from fm.serializers.spotify import TrackSerializer
 from fm.serializers.user import UserSerializer
 from fm.views.player import CurrentView
-from tests.factories.spotify import TrackFactory
-from tests.factories.user import UserFactory
 
 
 class BaseCurrentTest(object):

--- a/tests/views/player/test_history.py
+++ b/tests/views/player/test_history.py
@@ -11,6 +11,7 @@ Unit tests for the ``fm.views.player.HistoryView`` class.
 # Standard Libs
 import datetime
 
+# Third Party Libs
 # Third Pary Libs
 from dateutil.tz import tzutc
 from flask import url_for

--- a/tests/views/player/test_history.py
+++ b/tests/views/player/test_history.py
@@ -12,7 +12,6 @@ Unit tests for the ``fm.views.player.HistoryView`` class.
 import datetime
 
 # Third Party Libs
-# Third Pary Libs
 from dateutil.tz import tzutc
 from flask import url_for
 from tests.factories.spotify import PlaylistHistoryFactory

--- a/tests/views/player/test_mute.py
+++ b/tests/views/player/test_mute.py
@@ -11,7 +11,7 @@ Unit tests for the ``fm.views.player.MuteView`` class.
 # Standard Libs
 import json
 
-# Third Pary Libs
+# Third Party Libs
 import mock
 import pytest
 from flask import url_for

--- a/tests/views/player/test_pause.py
+++ b/tests/views/player/test_pause.py
@@ -11,7 +11,7 @@ Unit tests for the ``fm.views.player.PauseView`` class.
 # Standard Libs
 import json
 
-# Third Pary Libs
+# Third Party Libs
 import mock
 import pytest
 from flask import url_for

--- a/tests/views/player/test_queue.py
+++ b/tests/views/player/test_queue.py
@@ -97,12 +97,14 @@ class TestGetQueue(QueueTest):
                 config.PLAYLIST_REDIS_KEY,
                 json.dumps({
                     'uri': track.spotify_uri,
-                    'user': users[i].id
+                    'user': users[i].id,
+                    'uuid': '16fd2706-8baf-433b-82eb-8c7fada847da',
                 })
             )
             expected.append({
                 'track': TrackSerializer().serialize(track),
-                'user': UserSerializer().serialize(users[i])
+                'user': UserSerializer().serialize(users[i]),
+                'uuid': '16fd2706-8baf-433b-82eb-8c7fada847da',
             })
 
         url = url_for('player.queue')

--- a/tests/views/player/test_queue.py
+++ b/tests/views/player/test_queue.py
@@ -9,10 +9,10 @@ Unit tests for the ``fm.views.player.QueueView`` class.
 """
 
 # Standard Libs
+import httplib
 import json
 
-# Third Pary Libs
-import httplib
+# Third Party Libs
 import mock
 import pytest
 import requests
@@ -28,6 +28,7 @@ from fm.models.spotify import Artist
 from fm.models.user import User
 from fm.serializers.spotify import TrackSerializer
 from fm.serializers.user import UserSerializer
+from fm.session import current_user
 
 
 class QueueTest(object):
@@ -180,3 +181,52 @@ class TestQueuePost(QueueTest):
             'user': user.id
         }))
         update_genres.s.assert_called_with(Artist.query.all()[0].id)
+
+
+@pytest.mark.usefixtures("authenticated")
+class TestQueueDelete(QueueTest):
+
+    @pytest.mark.usefixtures("unauthenticated")
+    def must_be_authenticated(self):
+        url = url_for('player.queue')
+        response = self.client.delete(url, data=json.dumps({
+            'uri': 'foo',
+            'uuid': '16fd2706-8baf-433b-82eb-8c7fada847da',
+        }))
+
+        assert response.status_code == httplib.UNAUTHORIZED
+
+    def should_delete_track_in_queue(self):
+        tracks = [TrackFactory() for i in range(3)]
+        db.session.add_all(tracks)
+        db.session.commit()
+
+        for i, track in enumerate(tracks):
+            self.redis.rpush(
+                config.PLAYLIST_REDIS_KEY,
+                json.dumps({
+                    'uri': track.spotify_uri,
+                    'user': current_user.id,
+                    'uuid': '16fd2706-8baf-433b-82eb-8c7fada847da',
+                })
+            )
+
+        url = url_for('player.queue')
+        response = self.client.delete(url, data=json.dumps({
+            'uri': tracks[1].spotify_uri,
+            'uuid': '16fd2706-8baf-433b-82eb-8c7fada847da',
+        }))
+
+        assert response.status_code == httplib.OK
+        assert self.redis.llen(config.PLAYLIST_REDIS_KEY) == 2
+
+    def should_return_no_content_for_non_existing_key(self):
+        track = TrackFactory.create()
+
+        url = url_for('player.queue')
+        response = self.client.delete(url, data=json.dumps({
+            'uri': track.spotify_uri,
+            'uuid': 'blabla',
+        }))
+
+        assert response.status_code == httplib.NO_CONTENT

--- a/tests/views/player/test_queue_meta.py
+++ b/tests/views/player/test_queue_meta.py
@@ -11,7 +11,7 @@ Unit tests for the ``fm.views.player.QueueMetaView`` class.
 # Standard Libs
 import json
 
-# Third Pary Libs
+# Third Party Libs
 import mock
 from flask import url_for
 from mockredis import mock_redis_client

--- a/tests/views/player/test_random.py
+++ b/tests/views/player/test_random.py
@@ -12,17 +12,17 @@ Unit tests for the ``fm.views.player.RandomView`` class.
 import httplib
 import json
 
-# Third Pary Libs
+# Third Party Libs
 import mock
 import pytest
 from flask import url_for
 from mockredis import mock_redis_client
+from tests.factories.spotify import TrackFactory
+from tests.factories.user import UserFactory
 
 # First Party Libs
 from fm.ext import db
 from fm.logic.player import Queue
-from tests.factories.spotify import TrackFactory
-from tests.factories.user import UserFactory
 
 
 @pytest.mark.usefixtures("authenticated")

--- a/tests/views/player/test_volume.py
+++ b/tests/views/player/test_volume.py
@@ -11,7 +11,7 @@ Unit tests for the ``fm.views.player.VolumeView`` class.
 # Standard Libs
 import json
 
-# Third Pary Libs
+# Third Party Libs
 import mock
 import pytest
 from flask import url_for

--- a/tests/views/user/test_authenticated.py
+++ b/tests/views/user/test_authenticated.py
@@ -7,8 +7,6 @@ tests.views.user.test_authenticated
 
 Unit tests for the ``fm.views.user.UserAuthenticatedView`` class.
 """
-
-# Third Pary Libs
 # Third Party Libs
 from flask import g, url_for
 from tests.factories.user import UserFactory

--- a/tests/views/user/test_authenticated.py
+++ b/tests/views/user/test_authenticated.py
@@ -9,12 +9,13 @@ Unit tests for the ``fm.views.user.UserAuthenticatedView`` class.
 """
 
 # Third Pary Libs
+# Third Party Libs
 from flask import g, url_for
+from tests.factories.user import UserFactory
 
 # First Party Libs
 from fm.ext import db
 from fm.serializers.user import UserSerializer
-from tests.factories.user import UserFactory
 
 
 class TestUserAuthenticatedGet(object):

--- a/tests/views/user/test_user.py
+++ b/tests/views/user/test_user.py
@@ -12,14 +12,14 @@ Unit tests for the ``fm.views.user.UserView`` class.
 import httplib
 import uuid
 
-# Third Pary Libs
+# Third Party Libs
 import mock
 from flask import url_for
+from tests.factories.user import UserFactory
 
 # First Party Libs
 from fm.ext import db
 from fm.serializers.user import UserSerializer
-from tests.factories.user import UserFactory
 
 
 class TestUserGet(object):


### PR DESCRIPTION
Extend queue endpoint for delete method to delete a track from the queue. Redis doesn't have an unique identificator to delete particular item from the queue. I've added a unique value to a queue item to make sure that correct item will be removed. 

FE has to send a track uri and an unique value to delete an item. User can delete only its own tracks. 