### PR TITLE
Fix: cors Access-Control-Expose-Headers

### DIFF
--- a/fm/http/cors.py
+++ b/fm/http/cors.py
@@ -16,7 +16,7 @@ HEADERS = {
     'CREDENTIALS': 'Access-Control-Allow-Credentials',
     'ORIGIN': 'Access-Control-Allow-Origin',
     'MAX_AGE': 'Access-Control-Allow-Max-Age',
-    'EXPOSE_HEADERS': 'Access-Control-Allow-Expose-Headers',
+    'EXPOSE_HEADERS': 'Access-Control-Expose-Headers',
     'HEADERS': 'Access-Control-Allow-Headers'
 }
 


### PR DESCRIPTION
Bloddy CORS not exposing pagination headers. Testing against FE, swapping this header fixes it.