### PR TITLE
Feature: User stats

### DIFF
--- a/fm/routes/user.py
+++ b/fm/routes/user.py
@@ -21,7 +21,7 @@ routes = [
     # /users/{id}
     Pluggable('/<pk>', user.UserView, 'user'),
     # /users/{id}/stats
-    Pluggable('/<pk>/stats/', user.UserStatsView, 'user_stats'),
+    Pluggable('/<pk>/stats/', user.UserStatsView, 'stats'),
 
     Pluggable('/<user_pk>/spotify-playlists/',
               user.UserSpotifyPlaylistView, 'user_spotify_playlists'),

--- a/fm/routes/user.py
+++ b/fm/routes/user.py
@@ -20,6 +20,8 @@ routes = [
     Pluggable('/authenticated', user.UserAuthenticatedView, 'authenticated'),
     # /users/{id}
     Pluggable('/<pk>', user.UserView, 'user'),
+    # /users/{id}/stats
+    Pluggable('/<pk>/stats/', user.UserStatsView, 'user_stats'),
 
     Pluggable('/<user_pk>/spotify-playlists/',
               user.UserSpotifyPlaylistView, 'user_spotify_playlists'),

--- a/fm/views/user.py
+++ b/fm/views/user.py
@@ -10,7 +10,7 @@ Views for working with User objects.
 
 # Standard Libs
 import uuid
-from datetime import datetime, timedelta
+from datetime import datetime
 
 # Third Party Libs
 import pytz
@@ -41,8 +41,7 @@ from fm.models.spotify import (
     Track
 )
 from fm.serializers.spotify import (
-    ArtistSerializer,
-    TrackSerializer
+    ArtistSerializer
 )
 
 

--- a/tests/views/user/test_stats.py
+++ b/tests/views/user/test_stats.py
@@ -1,0 +1,373 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+"""
+tests.views.user.test_stats
+===============================
+
+Unit tests for the ``fm.views.user.UserStatsView`` class.
+"""
+# Standard Libs
+import datetime
+
+# Third Party Libs
+from dateutil.tz import tzutc
+from flask import url_for
+from tests.factories.spotify import (
+    AlbumWithArtist,
+    ArtistFactory,
+    GenreFactory,
+    PlaylistHistoryFactory,
+    TrackFactory,
+    UserFactory
+)
+
+# First Party Libs
+from fm.ext import db
+from fm.thirdparty.spotify import TrackSerializer
+from fm.serializers.spotify import ArtistSerializer
+
+
+class TestGetStats(object):
+
+    def should_return_played_tracks_since_selected_date(self):
+        user = UserFactory()
+        most_played = TrackFactory()
+        second_most_played = TrackFactory()
+        entries = [
+            user,
+            PlaylistHistoryFactory(track=most_played, user=user),
+            PlaylistHistoryFactory(track=most_played, user=user),
+            PlaylistHistoryFactory(track=second_most_played, user=user),
+            PlaylistHistoryFactory(track=second_most_played),
+            PlaylistHistoryFactory(
+                track=second_most_played,
+                user=user,
+                created=datetime.datetime(2014, 1, 1, tzinfo=tzutc())
+            ),
+            PlaylistHistoryFactory(
+                created=datetime.datetime(2014, 1, 1, tzinfo=tzutc())
+            ),
+        ]
+        db.session.add_all(entries)
+        db.session.commit()
+
+        url = url_for('users.stats', pk=user.id, since='2015-06-01')
+        response = self.client.get(url)
+
+        assert response.status_code == 200
+        assert response.json['most_played_tracks'] == [
+            {
+                'track': TrackSerializer().serialize(most_played),
+                'total': 2
+            },
+            {
+                'track': TrackSerializer().serialize(second_most_played),
+                'total': 1
+            },
+        ]
+
+    def should_return_played_tracks_from_the_beginning_of_the_age(self):
+        user = UserFactory()
+        most_played = TrackFactory()
+        second_most_played = TrackFactory()
+        entries = [
+            user,
+            PlaylistHistoryFactory(track=most_played, user=user),
+            PlaylistHistoryFactory(track=most_played, user=user),
+            PlaylistHistoryFactory(track=second_most_played, user=user),
+            PlaylistHistoryFactory(track=second_most_played),
+        ]
+        db.session.add_all(entries)
+        db.session.commit()
+
+        url = url_for('users.stats', pk=user.id)
+        response = self.client.get(url)
+
+        assert response.status_code == 200
+        assert response.json['most_played_tracks'] == [
+            {
+                'track': TrackSerializer().serialize(most_played),
+                'total': 2
+            },
+            {
+                'track': TrackSerializer().serialize(second_most_played),
+                'total': 1
+            },
+        ]
+
+    def should_return_most_played_artist_since_selected_date(self):
+        user = UserFactory()
+        most_played = ArtistFactory()
+        second_most_played = ArtistFactory()
+        entries = [
+            user,
+            PlaylistHistoryFactory(
+                track=TrackFactory(
+                    album=AlbumWithArtist(artists=[most_played])
+                ),
+                user=user
+            ),
+            PlaylistHistoryFactory(
+                track=TrackFactory(
+                    album=AlbumWithArtist(artists=[second_most_played])
+                )
+            ),
+            PlaylistHistoryFactory(
+                created=datetime.datetime(2014, 1, 1, tzinfo=tzutc()),
+                track=TrackFactory(
+                    album=AlbumWithArtist(
+                        artists=[second_most_played, most_played]
+                    )
+                ),
+                user=user
+            ),
+        ]
+        db.session.add_all(entries)
+        db.session.commit()
+
+        url = url_for('users.stats', pk=user.id, since='2015-06-01')
+        response = self.client.get(url)
+
+        assert response.status_code == 200
+        assert response.json['most_played_artists'] == [
+            {
+                'artist': ArtistSerializer().serialize(most_played),
+                'total': 1
+            },
+        ]
+
+    def should_return_most_played_artist_from_the_beginning_of_the_age(self):
+        user = UserFactory()
+        most_played = ArtistFactory()
+        second_most_played = ArtistFactory()
+        entries = [
+            user,
+            PlaylistHistoryFactory(
+                track=TrackFactory(
+                    album=AlbumWithArtist(artists=[most_played])
+                ),
+                user=user
+            ),
+            PlaylistHistoryFactory(
+                track=TrackFactory(
+                    album=AlbumWithArtist(
+                        artists=[second_most_played, most_played]
+                    )
+                ),
+                user=user
+            ),
+            PlaylistHistoryFactory(
+                track=TrackFactory(
+                    album=AlbumWithArtist(artists=[second_most_played])
+                )
+            ),
+        ]
+        db.session.add_all(entries)
+        db.session.commit()
+
+        url = url_for('users.stats', pk=user.id)
+        response = self.client.get(url)
+
+        assert response.status_code == 200
+        assert response.json['most_played_artists'] == [
+            {
+                'artist': ArtistSerializer().serialize(most_played),
+                'total': 2
+            },
+            {
+                'artist': ArtistSerializer().serialize(second_most_played),
+                'total': 1
+            },
+        ]
+
+    def should_return_most_played_genre_from_the_beginning_of_the_age(self):
+        user = UserFactory()
+        most_played = GenreFactory()
+        second_most_played = GenreFactory()
+        entries = [
+            user,
+            PlaylistHistoryFactory(
+                track=TrackFactory(
+                    album=AlbumWithArtist(
+                        artists=[ArtistFactory(
+                            genres=[most_played])
+                        ]
+                    )
+                ),
+                user=user
+            ),
+            PlaylistHistoryFactory(
+                track=TrackFactory(
+                    album=AlbumWithArtist(
+                        artists=[ArtistFactory(
+                            genres=[second_most_played, most_played])
+                        ]
+                    )
+                ),
+                user=user
+            ),
+            PlaylistHistoryFactory(
+                track=TrackFactory(
+                    album=AlbumWithArtist(
+                        artists=[ArtistFactory(
+                            genres=[second_most_played])
+                        ]
+                    )
+                )
+            ),
+        ]
+        db.session.add_all(entries)
+        db.session.commit()
+
+        url = url_for('users.stats', pk=user.id)
+        response = self.client.get(url)
+
+        assert response.status_code == 200
+        assert response.json['most_played_genres'] == [
+            {
+                'name': most_played.name,
+                'total': 2
+            },
+            {
+                'name': second_most_played.name,
+                'total': 1
+            },
+        ]
+
+    def should_return_most_played_genre_since_selected_date(self):
+        user = UserFactory()
+        most_played = GenreFactory()
+        second_most_played = GenreFactory()
+        entries = [
+            user,
+            PlaylistHistoryFactory(
+                track=TrackFactory(
+                    album=AlbumWithArtist(
+                        artists=[ArtistFactory(
+                            genres=[most_played])]
+                    )
+                ),
+                user=user
+            ),
+            PlaylistHistoryFactory(
+                track=TrackFactory(
+                    album=AlbumWithArtist(
+                        artists=[ArtistFactory(
+                            genres=[most_played])]
+                    )
+                )
+            ),
+            PlaylistHistoryFactory(
+                created=datetime.datetime(2014, 1, 1, tzinfo=tzutc()),
+                track=TrackFactory(
+                    album=AlbumWithArtist(
+                        artists=[ArtistFactory(
+                            genres=[second_most_played, most_played])]
+                    )
+                ),
+                user=user
+            ),
+        ]
+        db.session.add_all(entries)
+        db.session.commit()
+
+        url = url_for('users.stats', pk=user.id, since='2015-06-01')
+        response = self.client.get(url)
+
+        assert response.status_code == 200
+        assert response.json['most_played_genres'] == [
+            {
+                'name': most_played.name,
+                'total': 1
+            },
+        ]
+
+    def should_return_played_time_from_the_beginning_of_the_age(self):
+        user = UserFactory()
+        entries = [
+            user,
+            PlaylistHistoryFactory(
+                user=user,
+                track=TrackFactory(duration=1000)),
+            PlaylistHistoryFactory(
+                user=user,
+                track=TrackFactory(duration=500)),
+            PlaylistHistoryFactory(
+                user=user,
+                track=TrackFactory(duration=700)),
+            PlaylistHistoryFactory(
+                track=TrackFactory(duration=700)),
+        ]
+        db.session.add_all(entries)
+        db.session.commit()
+
+        url = url_for('users.stats', pk=user.id)
+        response = self.client.get(url)
+
+        assert response.status_code == 200
+        assert response.json['total_play_time'] == 2200
+
+    def should_return_played_time_since_selected_date(self):
+        user = UserFactory()
+        entries = [
+            user,
+            PlaylistHistoryFactory(
+                user=user,
+                track=TrackFactory(duration=1000)),
+            PlaylistHistoryFactory(
+                user=user,
+                created=datetime.datetime(2014, 1, 1, tzinfo=tzutc()),
+                track=TrackFactory(duration=500)),
+            PlaylistHistoryFactory(
+                user=user,
+                track=TrackFactory(duration=700)),
+            PlaylistHistoryFactory(
+                track=TrackFactory(duration=700)),
+        ]
+        db.session.add_all(entries)
+        db.session.commit()
+
+        url = url_for('users.stats', pk=user.id, since='2015-06-01')
+        response = self.client.get(url)
+
+        assert response.status_code == 200
+        assert response.json['total_play_time'] == 1700
+
+    def should_return_total_plays_from_the_beginning_of_the_age(self):
+        user = UserFactory()
+        entries = [
+            user,
+            PlaylistHistoryFactory(user=user),
+            PlaylistHistoryFactory(user=user),
+            PlaylistHistoryFactory()
+        ]
+        db.session.add_all(entries)
+        db.session.commit()
+
+        url = url_for('users.stats', pk=user.id)
+        response = self.client.get(url)
+
+        assert response.status_code == 200
+        assert response.json['total_plays'] == 2
+
+    def should_return_total_plays_since_selected_date(self):
+        user = UserFactory()
+        entries = [
+            user,
+            PlaylistHistoryFactory(user=user),
+            PlaylistHistoryFactory(user=user),
+            PlaylistHistoryFactory(),
+            PlaylistHistoryFactory(
+                user=user,
+                created=datetime.datetime(2014, 1, 1, tzinfo=tzutc()),
+            )
+        ]
+        db.session.add_all(entries)
+        db.session.commit()
+
+        url = url_for('users.stats', pk=user.id, since='2015-06-01')
+        response = self.client.get(url)
+
+        assert response.status_code == 200
+        assert response.json['total_plays'] == 2


### PR DESCRIPTION
User stats at `/user/:id/stats`. Closes #43 

Also as this uses a lot of similar queries to `/player/stats` I'm wondering if there is a way to avoid this repetition and encapsulate this somewhere... 