### PR TITLE
Remove ? from url queue url pattern

### DIFF
--- a/fm/routes/player.py
+++ b/fm/routes/player.py
@@ -21,7 +21,7 @@ routes = [
     Pluggable('/history', player.HistoryView, 'history'),
     Pluggable('/stats', player.StatsView, 'stats'),
     Pluggable('/queue/', player.QueueView, 'queue'),
-    Pluggable('/queue/<string:uuid>?', player.QueueView, 'queue'),
+    Pluggable('/queue/<string:uuid>', player.QueueView, 'queue'),
     Pluggable('/queue/meta', player.QueueMetaView, 'queue-meta'),
     Pluggable('/volume', player.VolumeView, 'volume'),
     Pluggable('/mute', player.MuteView, 'mute'),


### PR DESCRIPTION
Question mark has been intended to be used as optional `uuid` field but has been forgotten.