### PR TITLE
Fix deleting tracks from the queue

### DIFF
--- a/fm/db/nosql.py
+++ b/fm/db/nosql.py
@@ -12,7 +12,7 @@ Classes for connecting to NoSQL data stores.
 import urlparse
 
 # Third Party Libs
-from redis import StrictRedis
+import redis
 
 
 class Redis(object):
@@ -74,7 +74,7 @@ class Redis(object):
 
         # Connect to Redis
         uri = urlparse.urlparse(app.config.get('REDIS_SERVER_URI'))
-        self.connection = StrictRedis(
+        self.connection = redis.Redis(
             host=uri.hostname,
             port=uri.port,
             password=uri.password,

--- a/fm/logic/player.py
+++ b/fm/logic/player.py
@@ -115,7 +115,7 @@ class Queue(object):
         for item in Queue.iterate():
             json_item = json.loads(item)
             if json_item.get('uuid') == uuid:
-                redis.lrem(config.PLAYLIST_REDIS_KEY, 1, item)
+                redis.lrem(config.PLAYLIST_REDIS_KEY, item, 1)
                 redis.publish(config.PLAYER_CHANNEL, json.dumps({
                     'event': 'deleted',
                     'uri': json_item['uri'],

--- a/fm/logic/player.py
+++ b/fm/logic/player.py
@@ -115,7 +115,7 @@ class Queue(object):
         for item in Queue.iterate():
             json_item = json.loads(item)
             if json_item.get('uuid') == uuid:
-                redis.lrem(key=config.PLAYLIST_REDIS_KEY, value=item, count=1)
+                redis.lrem(config.PLAYLIST_REDIS_KEY, 1, item)
                 redis.publish(config.PLAYER_CHANNEL, json.dumps({
                     'event': 'deleted',
                     'uri': json_item['uri'],

--- a/tests/views/player/test_queue.py
+++ b/tests/views/player/test_queue.py
@@ -233,7 +233,6 @@ class TestQueueDelete(QueueTest):
 
         assert response.status_code == httplib.UNAUTHORIZED
 
-    @pytest.mark.skipif(True, reason='Redis mock library is not fully compatible')
     def should_delete_track_in_queue(self):
         tracks = [TrackFactory() for i in range(3)]
         db.session.add_all(tracks)

--- a/tests/views/player/test_queue.py
+++ b/tests/views/player/test_queue.py
@@ -233,6 +233,7 @@ class TestQueueDelete(QueueTest):
 
         assert response.status_code == httplib.UNAUTHORIZED
 
+    @pytest.mark.skipif(True, reason='Redis mock library is not fully compatible')
     def should_delete_track_in_queue(self):
         tracks = [TrackFactory() for i in range(3)]
         db.session.add_all(tracks)


### PR DESCRIPTION
Use Redis class instead of StrictRedis. Redis class doesn't really follow redis commands in its functions but it's more compatible with redis mock lib. I've test api to add some tracks into queue etc and it seems to be working fine all test passed.