### PR TITLE
Fix: remove trailing slash from user/:id/stats resource

### DIFF
--- a/fm/routes/user.py
+++ b/fm/routes/user.py
@@ -21,7 +21,7 @@ routes = [
     # /users/{id}
     Pluggable('/<pk>', user.UserView, 'user'),
     # /users/{id}/stats
-    Pluggable('/<pk>/stats/', user.UserStatsView, 'stats'),
+    Pluggable('/<pk>/stats', user.UserStatsView, 'stats'),
 
     Pluggable('/<user_pk>/spotify-playlists/',
               user.UserSpotifyPlaylistView, 'user_spotify_playlists'),


### PR DESCRIPTION
Shouldn't require a trailing slash.