### PR TITLE
Feature: Allow Known Clients

### DIFF
--- a/fm/auth.py
+++ b/fm/auth.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+"""
+fm.auth
+=======
+
+Authentication decorators
+"""
+
+# Standard Libs
+from functools import wraps
+
+# First Party Libs
+from fm import clients, session
+from fm.http import Unauthorized
+
+
+def authenticated(function):
+    """ This decorator handles allowing access to tesources based on session
+    or known clients.
+    """
+
+    @wraps(function)
+    def wrapper(*args, **kwargs):
+        if not is_authenticated_request():
+            return Unauthorized()
+        return function(*args, **kwargs)
+
+    return wrapper
+
+
+def is_authenticated_request():
+    """ Retruns if the request is valid
+
+    Returns
+    -------
+    bool
+        If the requets is valid
+    """
+
+    # Known client?
+    if clients.valid_request():
+        return True
+
+    # Is a user session?
+    user = session.user_from_session()
+    if user is not None:
+        return True
+
+    return False

--- a/fm/clients.py
+++ b/fm/clients.py
@@ -9,11 +9,14 @@ Allow known external clients that are not users access to the API, these could
 be the Player or Volume control systems for example which are physical boxes
 that run outside of the network perimeter.
 
-Clients should send a Client-ID header which will correlate to a Private Key
-stored both on the Client and the Server. The Client will encode their request
-with this key, the server will check the request validity by also encoding
-the raw request with the same key and ensuring they match, this is known as
-HMAC.
+Clients should encode their request body with their private key using HMAC, this
+should then be sent with the Authorization Header with the username being the
+Clients ID and the password the signature.
+
+Example
+-------
+    GET /foo
+    Authorization: Soundwave frJIUN8DYpKDtOLCwo//yllqDzg=
 """
 
 # Standard Libs
@@ -50,7 +53,16 @@ def valid_request():
         If the request is from a trust client
     """
 
-    pass
+    try:
+        cid, sig = request.headers.get('Authorization', '').split()
+    except ValueError:
+        return False
+
+    key = get_private_key(cid)
+    if key is None:
+        return False
+
+    return False
 
 
 def get_private_key(client_id):

--- a/fm/clients.py
+++ b/fm/clients.py
@@ -15,13 +15,18 @@ Clients ID and the password the signature.
 
 Example
 -------
-    GET /foo
-    Authorization: Basic client:7f22960e19ce8d29d5c856667c4133c19339fefe2759e6d
+    GET / HTTP/1.1
+    Accept: */*
+    Accept-Encoding: gzip, deflate
+    Authorization: HMAC client:fyKWDhnOjSnVyFZmfEEzwZM5/v4nWebca33eCYuLX9Q=
+    Connection: keep-alive
 
-Clients should use SHA256 and send a Hex of the HMAC digest.
+Clients should use SHA256 to encode their requests and send a Base 64 encoded
+version of the HMAC digest.
 """
 
 # Standard Libs
+import base64
 import hashlib
 import hmac
 from functools import wraps
@@ -109,7 +114,7 @@ def validate_signature(key, expected):
     """
 
     # Generates a hex of the request digest based on the secret key
-    sig = hmac.new(key, request.body, hashlib.sha256).hexdigest()
+    sig = base64.b64decode(hmac.new(key, request.body, hashlib.sha256).digest())
 
     # Return if they match or not
     return sig == expected

--- a/fm/clients.py
+++ b/fm/clients.py
@@ -114,7 +114,7 @@ def validate_signature(key, expected):
     """
 
     # Generates a hex of the request digest based on the secret key
-    sig = base64.b64decode(hmac.new(key, request.body, hashlib.sha256).digest())
+    sig = base64.b64encode(hmac.new(key, request.body, hashlib.sha256).digest())
 
     # Return if they match or not
     return sig == expected

--- a/fm/clients.py
+++ b/fm/clients.py
@@ -63,7 +63,15 @@ def valid_request():
     """
 
     try:
-        cid, sig = request.headers.get('Authorization', '').split()
+        auth_type, auth_creds = request.headers.get('Authorization', '').split()
+    except ValueError:
+        return False
+
+    if not auth_type == 'HMAC':
+        return False
+
+    try:
+        cid, sig = auth_creds.split(':')
     except ValueError:
         return False
 
@@ -71,7 +79,7 @@ def valid_request():
     if key is None:
         return False
 
-    return valid_request(key, sig)
+    return validate_signature(key, sig)
 
 
 def get_private_key(client_id):

--- a/fm/clients.py
+++ b/fm/clients.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+"""
+fm.clients
+==========
+
+Allow known external clients that are not users access to the API, these could
+be the Player or Volume control systems for example which are physical boxes
+that run outside of the network perimeter.
+
+Clients should send a Client-ID header which will correlate to a Private Key
+stored both on the Client and the Server. The Client will encode their request
+with this key, the server will check the request validity by also encoding
+the raw request with the same key and ensuring they match, this is known as
+HMAC.
+"""
+
+# Standard Libs
+from functools import wraps
+
+# First Party Libs
+from fm.http import Unauthorized
+
+
+def known_client(function):
+    """ Decorator which requires that the view is accessible by only
+    known external clients.
+    """
+
+    @wraps(function)
+    def wrapper(*args, **kwargs):
+        if not valid_request():
+            return Unauthorized()
+        return function(*args, **kwargs)
+
+    return wrapper
+
+
+def valid_request():
+    pass

--- a/fm/clients.py
+++ b/fm/clients.py
@@ -19,6 +19,9 @@ HMAC.
 # Standard Libs
 from functools import wraps
 
+# Third Party Libs
+from flask import request
+
 # First Party Libs
 from fm.http import Unauthorized
 
@@ -38,4 +41,13 @@ def known_client(function):
 
 
 def valid_request():
+    """ Validates an incoming request from and ensures it comes from a trusted
+    source.
+
+    Returns
+    -------
+    bool
+        If the request is from a trust client
+    """
+
     pass

--- a/fm/clients.py
+++ b/fm/clients.py
@@ -16,10 +16,14 @@ Clients ID and the password the signature.
 Example
 -------
     GET /foo
-    Authorization: Soundwave frJIUN8DYpKDtOLCwo//yllqDzg=
+    Authorization: Basic client:7f22960e19ce8d29d5c856667c4133c19339fefe2759e6d
+
+Clients should use SHA256 and send a Hex of the HMAC digest.
 """
 
 # Standard Libs
+import hashlib
+import hmac
 from functools import wraps
 
 # Third Party Libs
@@ -85,3 +89,27 @@ def get_private_key(client_id):
     key = clients.get(client_id, None)
 
     return key
+
+
+def validate_signature(key, expected):
+    """ Validates the HMAC signature sent with the request, encoding the raw
+    request body and comparing the signatures.
+
+    Arguments
+    ---------
+    key : str
+        The client private key
+    expected : str
+        The signature expected
+
+    Returns
+    -------
+    bool
+        If the signatures match
+    """
+
+    # Generates a hex of the request digest based on the secret key
+    sig = hmac.new(key, request.body, hashlib.sha256).hexdigest()
+
+    # Return if they match or not
+    return sig == expected

--- a/fm/clients.py
+++ b/fm/clients.py
@@ -20,7 +20,7 @@ HMAC.
 from functools import wraps
 
 # Third Party Libs
-from flask import request
+from flask import current_app, request
 
 # First Party Libs
 from fm.http import Unauthorized
@@ -51,3 +51,25 @@ def valid_request():
     """
 
     pass
+
+
+def get_private_key(client_id):
+    """ Gets the private key for the client from Flask application
+    configuration.
+
+    Example
+    -------
+        >>> EXTERNAL_CLIENTS = {
+        >>>     'Client-ID': 'PrivateKey'
+        >>> }
+
+    Returns
+    -------
+    str or None
+        The clients private key or None if the client is not found
+    """
+
+    clients = current_app.config.get('EXTERNAL_CLIENTS', {})
+    key = clients.get(client_id, None)
+
+    return key

--- a/fm/clients.py
+++ b/fm/clients.py
@@ -71,7 +71,7 @@ def valid_request():
     if key is None:
         return False
 
-    return False
+    return valid_request(key, sig)
 
 
 def get_private_key(client_id):

--- a/fm/clients.py
+++ b/fm/clients.py
@@ -114,7 +114,7 @@ def validate_signature(key, expected):
     """
 
     # Generates a hex of the request digest based on the secret key
-    sig = base64.b64encode(hmac.new(key, request.body, hashlib.sha256).digest())
+    sig = base64.b64encode(hmac.new(key, request.data, hashlib.sha256).digest())
 
     # Return if they match or not
     return sig == expected

--- a/fm/clients.py
+++ b/fm/clients.py
@@ -18,7 +18,7 @@ Example
     GET / HTTP/1.1
     Accept: */*
     Accept-Encoding: gzip, deflate
-    Authorization: HMAC client:fyKWDhnOjSnVyFZmfEEzwZM5/v4nWebca33eCYuLX9Q=
+    Authorization: Basic Y2xpZW50OmZ5S1dEaG5PalNuVnlGWm1mRUV6d1pNNS92NG5XZWJjYTMzZUNZdUxYOVE9
     Connection: keep-alive
 
 Clients should use SHA256 to encode their requests and send a Base 64 encoded
@@ -67,11 +67,13 @@ def valid_request():
     except ValueError:
         return False
 
-    if not auth_type == 'HMAC':
+    try:
+        creds = base64.b64decode(auth_creds)
+    except TypeError:
         return False
 
     try:
-        cid, sig = auth_creds.split(':')
+        cid, sig = creds.split(':')
     except ValueError:
         return False
 

--- a/fm/clients.py
+++ b/fm/clients.py
@@ -38,7 +38,7 @@ from flask import current_app, request
 from fm.http import Unauthorized
 
 
-def known_client(function):
+def know_client_only_required(function):
     """ Decorator which requires that the view is accessible by only
     known external clients.
     """

--- a/fm/config/default.py
+++ b/fm/config/default.py
@@ -84,3 +84,10 @@ GOOGLE_REDIRECT_URI = os.environ.get('GOOGLE_REDIRECT_URI', 'postmessage')
 SPOTIFY_CLIENT_ID = os.environ.get('SPOTIFY_CLIENT_ID', None)
 SPOTIFY_CLIENT_SECRET = os.environ.get('SPOTIFY_CLIENT_SECRET', None)
 SPOTIFY_REDIRECT_URI = os.environ.get('SPOTIFY_REDIRECT_URI', 'postmessage')
+
+# Known External Clients
+
+EXTERNAL_CLIENTS = {
+    'Soundwave': os.environ.get('SOUNDWAVE_PRIV_KEY', None),
+    'Shockwave': os.environ.get('SHOCKWAVE_PRIV_KEY', None),
+}

--- a/fm/session.py
+++ b/fm/session.py
@@ -30,7 +30,7 @@ USER_SESSION_KEY = 'fm:api:user:session:{0}'
 current_user = LocalProxy(lambda: user_from_session())
 
 
-def authenticated(function):
+def session_only_required(function):
     """ Decorator which requires that the view is accessable only to users
     with a valid session.
     """

--- a/fm/views/oauth2.py
+++ b/fm/views/oauth2.py
@@ -23,7 +23,7 @@ from fm.logic.oauth import authorize_spotify_user
 from fm.models.user import User
 from fm.oauth2.google import GoogleOAuth2Exception, authenticate_oauth_code
 from fm.oauth2.spotify import SpotifyOAuth2Exception
-from fm.session import authenticated, current_user, make_session
+from fm.session import current_user, make_session, session_only_required
 
 
 class GoogleTestClientView(MethodView):
@@ -117,7 +117,7 @@ class GoogleConnectView(MethodView):
 
 class SpotifyConnectView(MethodView):
 
-    @authenticated
+    @session_only_required
     def get(self):
         try:
             code = request.args['code']

--- a/fm/views/player.py
+++ b/fm/views/player.py
@@ -27,6 +27,7 @@ from sqlalchemy import desc
 
 # First Party Libs
 from fm import http
+from fm.auth import authenticated
 from fm.ext import config, db, redis
 from fm.logic import stats
 from fm.logic.player import Queue, Random
@@ -39,7 +40,7 @@ from fm.serializers.spotify import (
     TrackSerializer
 )
 from fm.serializers.user import UserSerializer
-from fm.session import authenticated, current_user
+from fm.session import current_user
 from fm.tasks.queue import add, add_album
 
 

--- a/fm/views/user.py
+++ b/fm/views/user.py
@@ -25,7 +25,7 @@ from fm.models.spotify import PlaylistHistory
 from fm.models.user import User
 from fm.serializers.spotify import ArtistSerializer
 from fm.serializers.user import UserSerializer
-from fm.session import authenticated, current_user
+from fm.session import current_user, session_only_required
 from fm.thirdparty.spotify import (
     PlaylistSerializer,
     SpotifyApi,
@@ -37,7 +37,7 @@ class UserAuthenticatedView(MethodView):
     """ Authenticated User Resource - returns the currently authenticated user.
     """
 
-    @authenticated
+    @session_only_required
     def get(self):
         """ Returns the currently authenticated user
         """

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+"""
+tests.test_auth
+===============
+
+Unittests for the fm.auth module.
+"""
+
+# Third Party Libs
+import mock
+
+# First Party Libs
+from fm.auth import authenticated, is_authenticated_request
+from fm.http import Unauthorized
+
+
+class TestAuthenticatedDecorator(object):
+
+    @authenticated
+    def i_am_protected(self):
+        return True
+
+    @mock.patch('fm.auth.is_authenticated_request')
+    def test_returns_unauthorized(self, _is_authenticated_request):
+        _is_authenticated_request.return_value = False
+
+        response = self.i_am_protected()
+
+        assert type(response) == Unauthorized
+
+    @mock.patch('fm.auth.is_authenticated_request')
+    def test_returns_resource(self, _is_authenticated_request):
+        _is_authenticated_request.return_value = True
+
+        assert self.i_am_protected()
+
+
+class TestIsAuthenticatedRequest(object):
+
+    def test_returns_false_by_default(self):
+        assert is_authenticated_request() == False
+
+    @mock.patch('fm.auth.session.user_from_session')
+    def test_valid_session(self, _user_from_session):
+        _user_from_session.return_value = True
+
+        assert is_authenticated_request()
+
+    @mock.patch('fm.auth.clients.valid_request')
+    def test_valid_client(self, _valid_request):
+        _valid_request.return_value = True
+
+        assert is_authenticated_request()

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -112,7 +112,7 @@ class TestValidateRequest(object):
     @mock.patch('fm.clients.request')
     def test_invalid_auth_creds(self, _request):
         _request.headers = {
-            'Authorization': 'HMAC Bar'
+            'Authorization': 'Basic Bar'
         }
 
         assert valid_request() == False
@@ -121,17 +121,19 @@ class TestValidateRequest(object):
     def test_invalide_client_id(self, _request):
         h = hmac.new('foo', 'foo', hashlib.sha256)
         sig = base64.b64encode(h.digest())
+        creds = base64.b64encode('foo:{0}'.format(sig))
 
         _request.headers = {
-            'Authorization': 'HMAC foo:{0}'.format(sig)
+            'Authorization': 'Basic {0}'.format(creds)
         }
 
         assert valid_request() == False
 
     @mock.patch('fm.clients.request')
     def test_invalid_request(self, _request):
+        creds = base64.b64encode('foo:bar')
         _request.headers = {
-            'Authorization': 'HMAC foo:bar'
+            'Authorization': 'Basic {0}'.format(creds)
         }
         _request.data = 'foo'
         self.app.config['EXTERNAL_CLIENTS']['foo'] = 'bar'
@@ -142,9 +144,10 @@ class TestValidateRequest(object):
     def test_valid_request(self, _request):
         h = hmac.new('foo', 'foo', hashlib.sha256)
         sig = base64.b64encode(h.digest())
+        creds = base64.b64encode('foo:{0}'.format(sig))
 
         _request.headers = {
-            'Authorization': 'HMAC foo:{0}'.format(sig)
+            'Authorization': 'Basic {0}'.format(creds)
         }
         _request.data = 'foo'
         self.app.config['EXTERNAL_CLIENTS']['foo'] = 'foo'

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -35,7 +35,7 @@ class TestValidateSignature(object):
 
     @mock.patch('fm.clients.request')
     def test_return_false_no_match(self, _request):
-        _request.body = 'foo'
+        _request.data = 'foo'
 
         # Keys don't match
         key = 'bar'
@@ -46,7 +46,7 @@ class TestValidateSignature(object):
 
     @mock.patch('fm.clients.request')
     def test_return_true(self, _request):
-        _request.body = 'foo'
+        _request.data = 'foo'
 
         key = 'foo'
         h = hmac.new('foo', 'foo', hashlib.sha256)

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -19,7 +19,7 @@ import mock
 # First Party Libs
 from fm.clients import (
     get_private_key,
-    known_client,
+    know_client_only_required,
     valid_request,
     validate_signature
 )
@@ -28,7 +28,7 @@ from fm.http import Unauthorized
 
 class TestKnownClientDecorator(object):
 
-    @known_client
+    @know_client_only_required
     def i_am_protected(self):
         return True
 

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+"""
+tests.test_clients
+==================
+
+Unittests for known client autnentication
+"""
+
+# First Party Libs
+from fm.clients import get_private_key
+
+
+class TestGetPrivateKey(object):
+
+    def test_should_return_none(self):
+        assert get_private_key('foo') is None
+
+    def test_should_return_key(self):
+        self.app.config['EXTERNAL_CLIENTS']['FOO'] = 'bar'
+
+        assert get_private_key('FOO') == 'bar'

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -8,8 +8,16 @@ tests.test_clients
 Unittests for known client autnentication
 """
 
+# Standard Libs
+import base64
+import hashlib
+import hmac
+
+# Third Party Libs
+import mock
+
 # First Party Libs
-from fm.clients import get_private_key
+from fm.clients import get_private_key, validate_signature
 
 
 class TestGetPrivateKey(object):
@@ -21,3 +29,27 @@ class TestGetPrivateKey(object):
         self.app.config['EXTERNAL_CLIENTS']['FOO'] = 'bar'
 
         assert get_private_key('FOO') == 'bar'
+
+
+class TestValidateSignature(object):
+
+    @mock.patch('fm.clients.request')
+    def test_return_false_no_match(self, _request):
+        _request.body = 'foo'
+
+        # Keys don't match
+        key = 'bar'
+        h = hmac.new('foo', 'foo', hashlib.sha256)
+        sig = base64.b64encode(h.digest())
+
+        assert validate_signature(key, sig) == False
+
+    @mock.patch('fm.clients.request')
+    def test_return_true(self, _request):
+        _request.body = 'foo'
+
+        key = 'foo'
+        h = hmac.new('foo', 'foo', hashlib.sha256)
+        sig = base64.b64encode(h.digest())
+
+        assert validate_signature(key, sig)

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -15,7 +15,6 @@ import uuid
 import mock
 from flask import g
 from itsdangerous import URLSafeTimedSerializer
-from tests.factories.user import UserFactory
 
 # First Party Libs
 from fm.ext import db
@@ -23,16 +22,17 @@ from fm.http import Unauthorized
 from fm.session import (
     SESSION_KEY,
     USER_SESSION_KEY,
-    authenticated,
     make_session,
+    session_only_required,
     user_from_session,
     validate_session
 )
+from tests.factories.user import UserFactory
 
 
-class TestAuthenticated(object):
+class TestSessionOnlyDecorator(object):
 
-    @authenticated
+    @session_only_required
     def i_am_protected(self):
         return True
 


### PR DESCRIPTION
This PR implements the ability for known external clients, such as Soundwave to be able to use the API without the need for authentication as described in #60.

This uses a HMAC method where the client sends the request with a base 64 sha256 encrypted signature of the request using a private key. Provided the client and server agree the signature is correct the client is allowed access to the resource.

Example Request:

``` http
GET / HTTP/1.1
Accept: */*
Accept-Encoding: gzip, deflate
Authorization: HMAC client:fyKWDhnOjSnVyFZmfEEzwZM5/v4nWebca33eCYuLX9Q=
Connection: keep-alive
```

The `Authorization` header contains the HMAC identifier with the credentials being the client name and the signed request signature.

This will allow us to create external client specific resources and allow us to bypass the redis pubsub system in the long run.